### PR TITLE
refactor: 텍스트버튼 컴포넌트 수정

### DIFF
--- a/src/components/common/TextButton/TextButton.stories.tsx
+++ b/src/components/common/TextButton/TextButton.stories.tsx
@@ -3,7 +3,7 @@ import TextButton from "@/components/common/TextButton/TextButton";
 
 const meta = {
   // 스토리북 경로 - 파일 경로와 동일하게 설정하는 것이 좋을 것 같습니다.
-  title: "Components/common/TextButton/TextButton",
+  title: "Components/common/TextButton",
   component: TextButton,
   parameters: {
     // 스토리북 캔버스에 표시되는 위치
@@ -28,56 +28,29 @@ type Story = StoryObj<typeof meta>;
 // 기본 스토리
 export const Default: Story = {
   args: {
-    text: "기본 테스트",
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: "디폴트(small) 크기 버튼입니다.",
-      },
-    },
+    children: "기본 테스트",
+    size: "small",
   },
 };
 
 // size별 스토리
 export const Small: Story = {
   args: {
-    text: "기본 테스트",
+    children: "기본 테스트",
     size: "small",
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: "작은 크기 버튼입니다.",
-      },
-    },
   },
 };
 
 export const Medium: Story = {
   args: {
-    text: "기본 테스트",
+    children: "기본 테스트",
     size: "medium",
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: "중간 크기 버튼입니다.",
-      },
-    },
   },
 };
 
 export const Large: Story = {
   args: {
-    text: "기본 테스트",
+    children: "기본 테스트",
     size: "large",
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: "큰 크기 버튼입니다.",
-      },
-    },
   },
 };

--- a/src/components/common/TextButton/TextButton.tsx
+++ b/src/components/common/TextButton/TextButton.tsx
@@ -1,12 +1,12 @@
-import * as Style from "./Textbutton.style";
+import * as Style from "./TextButton.style";
 
 interface IProps {
-  text: string;
+  children: string;
   size?: "small" | "medium" | "large";
 }
 
-function Textbutton({ text, size }: IProps) {
-  return <Style.Container $size={size}>{text}</Style.Container>;
+function Textbutton({ children, size }: IProps) {
+  return <Style.Container $size={size}>{children}</Style.Container>;
 }
 
 export default Textbutton;


### PR DESCRIPTION
## 구현 요약

- 버튼안에 들어가는 글씨를 기존 props로 전달받는 형식에서 children으로 변경

### 연관 이슈

이 부분을 제거하고 연관된 이슈를 아래와 같이 명시해 닫아주세요.

close #20 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
