### PR TITLE
design: 카테고리 원형 색상 퍼블리싱

### DIFF
--- a/src/components/common/Circle/Circle.stories.tsx
+++ b/src/components/common/Circle/Circle.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Circle from "@/components/common/Circle/Circle";
+
+const meta = {
+  // 스토리북 경로 - 파일 경로와 동일하게 설정하는 것이 좋을 것 같습니다.
+  title: "components/common/Circle/Circle",
+  component: Circle,
+  parameters: {
+    // 스토리북 캔버스에 표시되는 위치
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "이 컴포넌트는 카테고리 리스트에서 보여주는 색상입니다. 원 모양처럼 안 보이지만 원 모양으로 제작되어 있습니다.",
+      },
+    },
+  },
+} satisfies Meta<typeof Circle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 스토리
+export const Default: Story = {
+  argTypes: {
+    backgroundColor: { control: "color" },
+  },
+  args: {
+    title: "기본 테스트",
+    description: "색을 기본으로 아무 값이나 넣어둔 상태입니다.",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "기본 테스트 컴포넌트입니다.",
+      },
+    },
+  },
+};

--- a/src/components/common/Circle/Circle.stories.tsx
+++ b/src/components/common/Circle/Circle.stories.tsx
@@ -15,6 +15,13 @@ const meta = {
       },
     },
   },
+  argTypes: {
+    color: {
+      control: "color",
+      description: "Circle의 배경 색상",
+      defaultValue: "#c9c9c9", // 기본 값 설정
+    },
+  },
 } satisfies Meta<typeof Circle>;
 
 export default meta;
@@ -22,12 +29,8 @@ type Story = StoryObj<typeof meta>;
 
 // 기본 스토리
 export const Default: Story = {
-  argTypes: {
-    backgroundColor: { control: "color" },
-  },
   args: {
-    title: "기본 테스트",
-    description: "색을 기본으로 아무 값이나 넣어둔 상태입니다.",
+    color: "#c9c9c9", // 기본 색상
   },
   parameters: {
     docs: {

--- a/src/components/common/Circle/Circle.style.tsx
+++ b/src/components/common/Circle/Circle.style.tsx
@@ -12,6 +12,7 @@ export const CircleColor = styled.div<{
 `;
 
 // CircleInput.tsx
+//  나중에 버튼이 생기기 때문에 div로 변경? / 값을 확인하기 해 form으로 작성
 export const ColorWrapper = styled.div`
   width: 100%;
   display: flex;

--- a/src/components/common/Circle/Circle.style.tsx
+++ b/src/components/common/Circle/Circle.style.tsx
@@ -1,0 +1,74 @@
+import styled from "styled-components";
+
+// Circle.tsx
+export const CircleColor = styled.div<{
+  $color: string;
+}>`
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: var(--border-radius-circle);
+  background-color: ${(props) => props.$color};
+`;
+
+// CircleInput.tsx
+export const ColorWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+`;
+
+export const ColorContainer = styled.div`
+  width: calc(100% - 4.5rem);
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const CircleBtn = styled.input.attrs({ type: "radio" })<{
+  $color: string;
+}>`
+  /* 기본 스타일 제거 및 커스텀 */
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+
+  width: 20px;
+  height: 20px;
+  border: 1px solid #ccc;
+  border-radius: var(--border-radius-circle);
+  outline: none;
+  cursor: pointer;
+  position: relative;
+  box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.25);
+  background-color: ${(props) => props.$color};
+
+  /* 체크 됐을 때 내부 모습 */
+  &:checked::after {
+    content: "✓";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: var(--font-size-small);
+    color: #111;
+  }
+`;
+
+export const CirclePicker = styled.input.attrs({ type: "color" })`
+  width: 20px;
+  height: 20px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: transparent;
+
+  padding: 0;
+  cursor: pointer;
+
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  &::-webkit-color-swatch {
+    border: none;
+  }
+`;

--- a/src/components/common/Circle/Circle.style.tsx
+++ b/src/components/common/Circle/Circle.style.tsx
@@ -12,7 +12,6 @@ export const CircleColor = styled.div<{
 `;
 
 // CircleInput.tsx
-//  나중에 버튼이 생기기 때문에 div로 변경? / 값을 확인하기 해 form으로 작성
 export const ColorWrapper = styled.div`
   width: 100%;
   display: flex;

--- a/src/components/common/Circle/Circle.tsx
+++ b/src/components/common/Circle/Circle.tsx
@@ -1,0 +1,8 @@
+import * as Styled from "./Circle.style";
+
+// 카테고리 리스트에서 보여주는 색상
+function Circle() {
+  return <Styled.CircleColor $color="#c8c8c8"></Styled.CircleColor>;
+}
+
+export default Circle;

--- a/src/components/common/Circle/Circle.tsx
+++ b/src/components/common/Circle/Circle.tsx
@@ -1,8 +1,12 @@
 import * as Styled from "./Circle.style";
 
+interface CircleProps {
+  color: string;
+}
+
 // 카테고리 리스트에서 보여주는 색상
-function Circle() {
-  return <Styled.CircleColor $color="#c8c8c8"></Styled.CircleColor>;
+function Circle({ color }: CircleProps) {
+  return <Styled.CircleColor $color={color}></Styled.CircleColor>;
 }
 
 export default Circle;

--- a/src/components/common/Circle/CircleInput.stories.tsx
+++ b/src/components/common/Circle/CircleInput.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import CircleInput from "@/components/common/Circle/CircleInput";
+
+const meta = {
+  // 스토리북 경로 - 파일 경로와 동일하게 설정하는 것이 좋을 것 같습니다.
+  title: "components/common/Circle/CircleInput",
+  component: CircleInput,
+  parameters: {
+    // 스토리북 캔버스에 표시되는 위치
+    layout: "centered",
+    docs: {
+      description: {
+        component: "이 컴포넌트는 카테고리 설정에서 보여주는 색상.",
+      },
+    },
+  },
+} satisfies Meta<typeof CircleInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 스토리
+export const Default: Story = {
+  argTypes: {
+    backgroundColor: { control: "color" },
+  },
+  args: {
+    title: "기본 테스트",
+    description: "색을 기본으로 아무 값이나 넣어둔 상태입니다.",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "기본 테스트 컴포넌트입니다.",
+      },
+    },
+  },
+};

--- a/src/components/common/Circle/CircleInput.tsx
+++ b/src/components/common/Circle/CircleInput.tsx
@@ -1,0 +1,26 @@
+import * as Styled from "./Circle.style";
+
+// 카테고리 설정에서 보여주는 색상
+// 선택 가능 하지만, radio와 color를 선택했을 때 어떤 것을 보낼지는 설정 필요
+function CircleInput() {
+  return (
+    <Styled.ColorWrapper>
+      <Styled.ColorContainer>
+        <Styled.CircleBtn name="color" $color="var(--color-category1)" />
+        <Styled.CircleBtn name="color" $color="var(--color-category2)" />
+        <Styled.CircleBtn name="color" $color="var(--color-category3)" />
+        <Styled.CircleBtn name="color" $color="var(--color-category4)" />
+        <Styled.CircleBtn name="color" $color="var(--color-category5)" />
+      </Styled.ColorContainer>
+      <Styled.ColorContainer>
+        <Styled.CircleBtn name="color" $color="var(--color-category6)" />
+        <Styled.CircleBtn name="color" $color="var(--color-category7)" />
+        <Styled.CircleBtn name="color" $color="var(--color-category8)" />
+        <Styled.CircleBtn name="color" $color="var(--color-category9)" />
+        <Styled.CirclePicker />
+      </Styled.ColorContainer>
+    </Styled.ColorWrapper>
+  );
+}
+
+export default CircleInput;

--- a/src/components/common/Circle/CircleInput.tsx
+++ b/src/components/common/Circle/CircleInput.tsx
@@ -1,23 +1,62 @@
 import * as Styled from "./Circle.style";
+import useCircleInput from "@/hooks/useCircleInput";
 
-// 카테고리 설정에서 보여주는 색상
-// 선택 가능 하지만, radio와 color를 선택했을 때 어떤 것을 보낼지는 설정 필요
 function CircleInput() {
+  const { selectedColor, handleChange } = useCircleInput();
+
   return (
     <Styled.ColorWrapper>
       <Styled.ColorContainer>
-        <Styled.CircleBtn name="color" $color="var(--color-category1)" />
-        <Styled.CircleBtn name="color" $color="var(--color-category2)" />
-        <Styled.CircleBtn name="color" $color="var(--color-category3)" />
-        <Styled.CircleBtn name="color" $color="var(--color-category4)" />
-        <Styled.CircleBtn name="color" $color="var(--color-category5)" />
+        {[
+          "var(--color-category1)",
+          "var(--color-category2)",
+          "var(--color-category3)",
+          "var(--color-category4)",
+          "var(--color-category5)",
+        ].map((color, index) => (
+          <Styled.CircleBtn
+            key={index}
+            name="color"
+            type="radio"
+            value={color}
+            $color={color}
+            checked={
+              selectedColor ===
+              getComputedStyle(document.documentElement)
+                .getPropertyValue(color.replace(/var\(|\)/g, "").trim())
+                .trim()
+            }
+            onChange={(e) => handleChange(e.target.value)} // 상태 변경
+          />
+        ))}
       </Styled.ColorContainer>
       <Styled.ColorContainer>
-        <Styled.CircleBtn name="color" $color="var(--color-category6)" />
-        <Styled.CircleBtn name="color" $color="var(--color-category7)" />
-        <Styled.CircleBtn name="color" $color="var(--color-category8)" />
-        <Styled.CircleBtn name="color" $color="var(--color-category9)" />
-        <Styled.CirclePicker />
+        {[
+          "var(--color-category6)",
+          "var(--color-category7)",
+          "var(--color-category8)",
+          "var(--color-category9)",
+        ].map((color, index) => (
+          <Styled.CircleBtn
+            key={index}
+            name="color"
+            type="radio"
+            value={color}
+            $color={color}
+            checked={
+              selectedColor ===
+              getComputedStyle(document.documentElement)
+                .getPropertyValue(color.replace(/var\(|\)/g, "").trim())
+                .trim()
+            }
+            onChange={(e) => handleChange(e.target.value)} // 상태 변경
+          />
+        ))}
+        <Styled.CirclePicker
+          type="color"
+          value={selectedColor} // 상태와 동기화
+          onChange={(e) => handleChange(e.target.value)} // color picker 선택
+        />
       </Styled.ColorContainer>
     </Styled.ColorWrapper>
   );

--- a/src/hooks/useCircleInput.ts
+++ b/src/hooks/useCircleInput.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+
+const useCircleInput = () => {
+  const [selectedColor, setSelectedColor] = useState<string>("#000000"); // 상태 공유
+
+  // 현재는 값을 확인하기 위해 onChange로 해두었는데,
+  // submit으로 변경하거나 useState를 추가하면 될 것 같습니다.
+  const handleChange = (value: string) => {
+    if (value.startsWith("var")) {
+      const computedStyle = getComputedStyle(document.documentElement);
+      const colorValue = computedStyle
+        .getPropertyValue(value.replace(/var\(|\)/g, "").trim())
+        .trim();
+      setSelectedColor(colorValue); // CSS 변수 -> HEX 변환
+    } else {
+      setSelectedColor(value); // color picker 값 그대로 사용
+    }
+    console.log(`Selected Color: ${selectedColor}`);
+  };
+
+  return { selectedColor, handleChange };
+};
+
+export default useCircleInput;

--- a/src/index.css
+++ b/src/index.css
@@ -40,6 +40,17 @@ html {
   --text-primary: var(--color-black);
   --text-secondary: var(--color-gray-dark);
 
+  /* 카테고리 기본 색상 설정 */
+  --color-category1: #ffe1fd;
+  --color-category2: #ffe3e1;
+  --color-category3: #fff0e1;
+  --color-category4: #fbffe1;
+  --color-category5: #ebffe1;
+  --color-category6: #e1e1ff;
+  --color-category7: #e1edff;
+  --color-category8: #e1fbff;
+  --color-category9: #e8e8e8;
+
   /* breakpoint */
   --breakpoint-mobile: 768px;
 }


### PR DESCRIPTION
## 구현 요약

- 카테고리에 사용되는 원형 색상을 퍼블리싱했습니다.
이때 카테고리 리스트에서 보여주는 원형 색은 color props를 통해 색을 지정해주면 됩니다.

- 카테고리 설정은 9가지의 색, 자유롭게 고를 수 있는 1가지, 총 10개로 선택할 수 있도록했습니다.
  - hook 파일을 분리하여 선택된 색을 콘솔에 나타나도록 해두었습니다.

### 화면
<img width="341" alt="image" src="https://github.com/user-attachments/assets/ad17b044-be1f-4881-ab54-174e9e52a9bc">

- 빨간 원은 리스트 색상으로 props 값으로 `red`를 넘겨줬습니다.
- 카테고리 색 선택(설정)의 색은 `index.css`에 정의해두었고 선택하면 `console.log`에 나타나도록 해두었습니다.

### 연관 이슈

- ex) close #11 

## 체크 리스트

- [x] merge 브랜치 확인했나요?
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
