### PR TITLE
feat: 시간입력 컴포넌트 구현 및 스토리북 추가

### DIFF
--- a/src/components/common/TimeInput/TimeInput.stories.tsx
+++ b/src/components/common/TimeInput/TimeInput.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import TimeInput from "./TimeInput";
+
+const meta = {
+  title: "Components/TimeInput",
+  component: TimeInput,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "이 컴포넌트는 시작 시간과 종료 시간을 선택하는 입력 컴포넌트입니다.",
+      },
+    },
+  },
+  argTypes: {
+    onChange: { action: "changed" }, // onChange 함수에 대한 액션을 기록
+    defaultStartTime: { control: "text" }, // 시작 시간을 텍스트로 설정
+    defaultEndTime: { control: "text" }, // 종료 시간을 텍스트로 설정
+    withEndTime: { control: "boolean" }, // 종료 시간 사용 여부
+  },
+} satisfies Meta<typeof TimeInput>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// 기본 스토리
+export const Default: Story = {
+  args: {
+    defaultStartTime: "09:00",
+    defaultEndTime: "10:00",
+    withEndTime: false,
+    onChange: (startTime: string, endTime?: string) => {
+      // onChange 속성 추가
+      console.log("Time changed:", startTime, endTime);
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "시작 시간만 선택할 수 있는 기본 상태입니다.",
+      },
+    },
+  },
+};
+
+// 종료 시간이 포함된 상태
+export const WithEndTime: Story = {
+  args: {
+    defaultStartTime: "09:00",
+    defaultEndTime: "10:00",
+    withEndTime: true,
+    onChange: (startTime: string, endTime?: string) => {
+      // onChange 속성 추가
+      console.log("Time changed:", startTime, endTime);
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "시작 시간과 종료 시간을 모두 선택할 수 있는 상태입니다.",
+      },
+    },
+  },
+};
+
+// 종료 시간이 비활성화된 상태
+export const NoEndTime: Story = {
+  args: {
+    defaultStartTime: "09:00",
+    withEndTime: false,
+    onChange: (startTime: string, endTime?: string) => {
+      // onChange 속성 추가
+      console.log("Time changed:", startTime, endTime);
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "종료 시간 선택이 비활성화된 상태입니다.",
+      },
+    },
+  },
+};

--- a/src/components/common/TimeInput/TimeInput.style.ts
+++ b/src/components/common/TimeInput/TimeInput.style.ts
@@ -1,0 +1,26 @@
+import styled from "styled-components";
+import "@/index.css";
+
+export const Container = styled.div`
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+`;
+
+export const StyledTimeInput = styled.input.attrs({ type: "time" })`
+  width: 100%;
+  border: none;
+  border-bottom: 1px solid var(--color-gray-light);
+  padding: 0.5rem;
+  font-size: var(--font-size-medium);
+  color: var(--color-black);
+  outline: none;
+
+  &:focus {
+    border-bottom: 1px solid var(--color-primary);
+  }
+
+  &::placeholder {
+    color: var(--color-gray-light);
+  }
+`;

--- a/src/components/common/TimeInput/TimeInput.tsx
+++ b/src/components/common/TimeInput/TimeInput.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import * as Style from "./TimeInput.style";
+
+interface TimeInputProps {
+  defaultStartTime?: string; // default 시작시간
+  defaultEndTime?: string; // default 종료시간
+  withEndTime?: boolean; // 종료시간 옵션 (true: 사용, false: 사용하지 않음)
+  onChange: (startTime: string, endTime?: string) => void; // 시간 바뀔때마다 호출해서 바뀐 시간 전달
+}
+
+function TimeInput({
+  defaultStartTime = "09:00",
+  defaultEndTime = "10:00",
+  withEndTime = false,
+  onChange,
+}: TimeInputProps) {
+  const [startTime, setStartTime] = useState(defaultStartTime);
+  const [endTime, setEndTime] = useState(defaultEndTime);
+
+  const handleStartTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newStartTime = e.target.value;
+    if (withEndTime && endTime && newStartTime > endTime) {
+      alert("시작 시간을 다시 입력해주세요.");
+    } else {
+      setStartTime(newStartTime);
+      onChange(newStartTime, endTime);
+    }
+  };
+
+  const handleEndTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!withEndTime) return; // 종료 시간이 사용되지 않을 때는 X
+    const newEndTime = e.target.value;
+    if (newEndTime >= startTime) {
+      setEndTime(newEndTime);
+      onChange(startTime, endTime);
+    } else {
+      alert("종료 시간을 다시 입력해주세요.");
+    }
+  };
+
+  return (
+    <Style.Container>
+      <Style.StyledTimeInput
+        id="start-time"
+        type="time"
+        value={startTime}
+        onChange={handleStartTimeChange}
+      />
+      {withEndTime && (
+        <>
+          →
+          <Style.StyledTimeInput
+            id="end-time"
+            type="time"
+            value={endTime || ""}
+            onChange={handleEndTimeChange}
+          />
+        </>
+      )}
+    </Style.Container>
+  );
+}
+
+export default TimeInput;


### PR DESCRIPTION
## 구현 요약

투두, 일정 작성 시 사용되는 시간 입력 컴포넌트입니다 !

```typescript
interface TimeInputProps {
  defaultStartTime?: string; // default 시작시간
  defaultEndTime?: string; // default 종료시간
  withEndTime?: boolean; // 종료시간 옵션 (true: 사용, false: 사용하지 않음)
  onChange: (startTime: string, endTime?: string) => void; // 시간 바뀔때마다 호출해서 바뀐 시간 전달
}
``` 

### default 시작시간
`defaultStartTime?: string;`
09:00으로 기본 설정 해두었는데 수정하실 수 있습니다
</br>

### default 종료시간
`defaultEndTime?: string;`
10:00으로 기본 설정 해두었고 이것도 수정 가능합니다
</br>

### 종료시간 옵션 (true: 사용, false: 사용하지 않음)
`withEndTime?: boolean;`
일정에서만 종료시간이 필요하기 때문에 옵션으로 넣어뒀습니다
</br>

### 시간 바뀔때마다 호출해서 바뀐 시간 전달
`onChange: (startTime: string, endTime?: string) => void;`
페이지에서 시간 변경될때마다 전달받는 함수 작성해주시면 됩니다
</br>


<img width="644" alt="스크린샷 2024-11-27 오전 11 30 09" src="https://github.com/user-attachments/assets/c72a0878-1361-47bb-8a24-17cede205f00">


시간 선택 부분은 라이브러리를 못찾아서 기본 디자인입니다
라이브러리 괜찮은거 있으면 추천 부탁드려요.. !


시간이 string으로 되어있어서 백엔드로 보낼 때는 time으로 변환하는 함수 만들어서 사용하셔야됩니다 !

### 연관 이슈

- ex) close #22 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
