### PR TITLE
feat:프로필 이미지 컴포넌트 구현 및 스토리북 추가

### DIFF
--- a/src/components/common/ProfileImg/ProfileImg.stories.tsx
+++ b/src/components/common/ProfileImg/ProfileImg.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ProfileImg from "@/components/common/ProfileImg/ProfileImg";
+
+const meta = {
+  title: "Components/common/ProfileImg/ProfileImg",
+  component: ProfileImg,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "프로필 이미지를 렌더링하는 컴포넌트입니다.",
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["large", "medium", "small"],
+    },
+    src: { control: "text" },
+    alt: { control: "text" },
+  },
+} satisfies Meta<typeof ProfileImg>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 스토리
+export const Default: Story = {
+  args: {
+    size: "medium",
+    src: "https://via.placeholder.com/120",
+    alt: "Default Profile Image",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "기본 프로필 이미지입니다.",
+      },
+    },
+  },
+};
+
+// Large 사이즈 이미지
+export const Large: Story = {
+  args: {
+    size: "large",
+    src: "https://via.placeholder.com/120",
+    alt: "Large Profile Image",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Large 크기의 프로필 이미지입니다.",
+      },
+    },
+  },
+};
+
+// Medium 사이즈 이미지
+export const Medium: Story = {
+  args: {
+    size: "medium",
+    src: "https://via.placeholder.com/120",
+    alt: "Medium Profile Image",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Medium 크기의 프로필 이미지입니다.",
+      },
+    },
+  },
+};
+
+// Small 사이즈 이미지
+export const Small: Story = {
+  args: {
+    size: "small",
+    src: "https://via.placeholder.com/120",
+    alt: "Small Profile Image",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Small 크기의 프로필 이미지입니다.",
+      },
+    },
+  },
+};

--- a/src/components/common/ProfileImg/ProfileImg.style.ts
+++ b/src/components/common/ProfileImg/ProfileImg.style.ts
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+const ImgSize = {
+  large: 120,
+  medium: 30,
+  small: 20,
+};
+
+export const StyledProfileImg = styled.img<{
+  size: "large" | "medium" | "small";
+}>`
+  width: ${({ size }) => ImgSize[size]}px;
+  height: ${({ size }) => ImgSize[size]}px;
+  border-radius: 50%;
+  object-fit: cover;
+`;

--- a/src/components/common/ProfileImg/ProfileImg.tsx
+++ b/src/components/common/ProfileImg/ProfileImg.tsx
@@ -1,0 +1,13 @@
+import * as Style from "./ProfileImg.style";
+
+interface ProfileImgProps {
+  size: "large" | "medium" | "small"; // 이미지 크기별 옵션
+  src: string; // 프로필 이미지 소스
+  alt?: string;
+}
+
+function ProfileImg({ size, src, alt = "Profile Image" }: ProfileImgProps) {
+  return <Style.StyledProfileImg size={size} src={src} alt={alt} />;
+}
+
+export default ProfileImg;


### PR DESCRIPTION
## 구현 요약
### 사이즈별로 프로필 이미지 크기를 설정한 컴포넌트 구현

```typescript
interface ProfileImgProps {
  size: "large" | "medium" | "small"; // 이미지 크기별 옵션 (필수 입력)
  src: string; // 프로필 이미지 소스 (필수 입력)
  alt?: string;
}
``` 

large 120*120
medium 30 * 30
small 20 * 20

이미지 사용할때 컴포넌트 이용해서 사이즈 간단하게 설정하시면 됩니다 !

### 연관 이슈

- ex) close #37  

## 체크 리스트

- [x] merge 브랜치 확인했나요?
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
