### PR TITLE
design: 투두/일정 리스트에 들어가는 내용 퍼블리싱

### DIFF
--- a/src/components/common/ListBar/ListBar.stories.tsx
+++ b/src/components/common/ListBar/ListBar.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ListBar from "@/components/common/ListBar/ListBar";
+
+const meta = {
+  // 스토리북 경로 - 파일 경로와 동일하게 설정하는 것이 좋을 것 같습니다.
+  title: "components/common/ListBar/ListBar",
+  component: ListBar,
+  parameters: {
+    // 스토리북 캔버스에 표시되는 위치
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "이 컴포넌트는 카테고리 리스트에서 보여주는 색상입니다. 원 모양처럼 안 보이지만 원 모양으로 제작되어 있습니다.",
+      },
+    },
+  },
+  argTypes: {
+    color: {
+      control: "color",
+      description: "Circle의 배경 색상",
+      defaultValue: "#c9c9c9", // 기본 값 설정
+    },
+  },
+} satisfies Meta<typeof ListBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 스토리
+export const Default: Story = {
+  args: {
+    color: "#c9c9c9", // 기본 색상
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "기본 테스트 컴포넌트입니다.",
+      },
+    },
+  },
+};

--- a/src/components/common/ListBar/ListBar.style.tsx
+++ b/src/components/common/ListBar/ListBar.style.tsx
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const Bar = styled.div<{
+  $color: string;
+}>`
+  width: 6px;
+  height: 25px;
+  border-radius: 3px;
+  background-color: ${(props) => props.$color};
+`;

--- a/src/components/common/ListBar/ListBar.tsx
+++ b/src/components/common/ListBar/ListBar.tsx
@@ -1,0 +1,11 @@
+import * as Styled from "./ListBar.style";
+
+interface ListBarProps {
+  color: string;
+}
+
+function ListBar({ color = "red" }: ListBarProps) {
+  return <Styled.Bar $color={color} />;
+}
+
+export default ListBar;

--- a/src/components/common/ListBar/ListBar.tsx
+++ b/src/components/common/ListBar/ListBar.tsx
@@ -4,6 +4,7 @@ interface ListBarProps {
   color: string;
 }
 
+// 일정/투두 리스트의 막대바
 function ListBar({ color = "red" }: ListBarProps) {
   return <Styled.Bar $color={color} />;
 }

--- a/src/components/common/ScheduleList/ScheduleItem.stories.tsx
+++ b/src/components/common/ScheduleList/ScheduleItem.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ScheduleItem from "@/components/common/ScheduleList/ScheduleItem";
+
+const meta = {
+  // 스토리북 경로 - 파일 경로와 동일하게 설정하는 것이 좋을 것 같습니다.
+  title: "components/common/ScheduleList/ScheduleItem",
+  component: ScheduleItem,
+  parameters: {
+    // 스토리북 캔버스에 표시되는 위치
+    layout: "centered",
+    docs: {
+      description: {
+        component: "이 컴포넌트는 카테고리 리스트에서 일정을 담당합니다.",
+      },
+    },
+  },
+} satisfies Meta<typeof ScheduleItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 스토리
+export const Default: Story = {
+  args: {
+    values: ["12월 16일", "12월 20일"],
+    color: "#FFE3E1",
+    schedule: "기말고사",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "기본 테스트 컴포넌트입니다.",
+      },
+    },
+  },
+};

--- a/src/components/common/ScheduleList/ScheduleItem.style.tsx
+++ b/src/components/common/ScheduleList/ScheduleItem.style.tsx
@@ -5,6 +5,7 @@ export const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 5px;
   margin: 0 auto;
   padding: 0.5rem;
   border-bottom: 1px solid #97cdbd;

--- a/src/components/common/ScheduleList/ScheduleItem.style.tsx
+++ b/src/components/common/ScheduleList/ScheduleItem.style.tsx
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  width: calc(100% - 2rem);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 auto;
+  padding: 0.5rem;
+  border-bottom: 1px solid #97cdbd;
+`;
+
+export const Explan = styled.div`
+  width: 75%;
+  display: flex;
+  gap: 7px;
+  align-items: center;
+`;
+
+export const ScheduleText = styled.p`
+  width: 100%;
+  font-size: 1rem;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  word-break: break-all;
+`;

--- a/src/components/common/ScheduleList/ScheduleItem.tsx
+++ b/src/components/common/ScheduleList/ScheduleItem.tsx
@@ -1,0 +1,31 @@
+import * as Styled from "./ScheduleItem.style";
+import TextDate from "../TextDate/TextDate";
+import ListBar from "../ListBar/ListBar";
+
+interface ScheduleItemProps {
+  values: string[]; // 날짜 or 시간 시작 및 종료
+  color: string;
+  schedule: string;
+}
+
+// 일정 아이템, props 값은 임시로 설정해뒀습니다.
+// values는 시작/종료 값을 넣어주면 됩니다.
+//  ex. ["1월 00일", "10월 50일"], ["1 : 00", "12 : 00"]
+function ScheduleItem({
+  values = [],
+  color = "#E1FBFF",
+  schedule = "기말고사",
+}: ScheduleItemProps) {
+  return (
+    <Styled.Wrapper>
+      <Styled.Explan>
+        {values.length > 0 ? <TextDate values={values} /> : ""}
+        <ListBar color={color} />
+        <Styled.ScheduleText>{schedule}</Styled.ScheduleText>
+      </Styled.Explan>
+      <span>(수정 아이콘)</span>
+    </Styled.Wrapper>
+  );
+}
+
+export default ScheduleItem;

--- a/src/components/common/TextDate/TextDate.stories.tsx
+++ b/src/components/common/TextDate/TextDate.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import TextDate from "@/components/common/TextDate/TextDate";
+
+const meta = {
+  // 스토리북 경로 - 파일 경로와 동일하게 설정하는 것이 좋을 것 같습니다.
+  title: "components/common/TextDate/TextDate",
+  component: TextDate,
+  parameters: {
+    // 스토리북 캔버스에 표시되는 위치
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "이 컴포넌트는 카테고리 리스트에서 보여주는 색상입니다. 원 모양처럼 안 보이지만 원 모양으로 제작되어 있습니다.",
+      },
+    },
+  },
+} satisfies Meta<typeof TextDate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 스토리
+export const Default: Story = {
+  args: {
+    type: "day",
+    values: ["12월 16일", "12월 20일"],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "기본 테스트 컴포넌트입니다.",
+      },
+    },
+  },
+};
+
+export const Primary: Story = {
+  args: {
+    type: "time",
+    values: ["10 : 00", "10 : 50"],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "값으로 시간이 들어왔을 경우",
+      },
+    },
+  },
+};
+
+export const NoData: Story = {
+  args: {
+    type: "time",
+    values: [],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "값이 전달되지 않은 경우",
+      },
+    },
+  },
+};

--- a/src/components/common/TextDate/TextDate.stories.tsx
+++ b/src/components/common/TextDate/TextDate.stories.tsx
@@ -23,7 +23,6 @@ type Story = StoryObj<typeof meta>;
 // 기본 스토리
 export const Default: Story = {
   args: {
-    type: "day",
     values: ["12월 16일", "12월 20일"],
   },
   parameters: {
@@ -37,7 +36,6 @@ export const Default: Story = {
 
 export const Primary: Story = {
   args: {
-    type: "time",
     values: ["10 : 00", "10 : 50"],
   },
   parameters: {
@@ -51,7 +49,6 @@ export const Primary: Story = {
 
 export const NoData: Story = {
   args: {
-    type: "time",
     values: [],
   },
   parameters: {

--- a/src/components/common/TextDate/TextDate.style.tsx
+++ b/src/components/common/TextDate/TextDate.style.tsx
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const Text = styled.div`
+  font-size: var(--font-size-micro);
+`;

--- a/src/components/common/TextDate/TextDate.style.tsx
+++ b/src/components/common/TextDate/TextDate.style.tsx
@@ -1,5 +1,9 @@
 import styled from "styled-components";
 
+export const TextContainer = styled.div`
+  width: 4rem;
+`;
+
 export const Text = styled.div`
   font-size: var(--font-size-micro);
 `;

--- a/src/components/common/TextDate/TextDate.tsx
+++ b/src/components/common/TextDate/TextDate.tsx
@@ -1,28 +1,18 @@
 import * as Styled from "./TextDate.style";
 
 interface TextDateProps {
-  type: "day" | "time";
-  values: string[]; // 날짜 or 시간의 리스트
+  values: string[]; // 날짜 or 시간의 시작 및 종료
 }
 
-function TextDate({ type, values }: TextDateProps) {
+function TextDate({ values }: TextDateProps) {
   return (
-    <div>
-      {type === "day" && (
-        <div>
-          {values.map((day, index) => (
-            <Styled.Text key={`day-${index}`}>{day}</Styled.Text>
-          ))}
-        </div>
-      )}
-      {type === "time" && (
-        <div>
-          {values.map((time, index) => (
-            <Styled.Text key={`time-${index}`}>{time}</Styled.Text>
-          ))}
-        </div>
-      )}
-    </div>
+    <Styled.TextContainer>
+      <div>
+        {values.map((day, index) => (
+          <Styled.Text key={`day-${index}`}>{day}</Styled.Text>
+        ))}
+      </div>
+    </Styled.TextContainer>
   );
 }
 export default TextDate;

--- a/src/components/common/TextDate/TextDate.tsx
+++ b/src/components/common/TextDate/TextDate.tsx
@@ -1,0 +1,28 @@
+import * as Styled from "./TextDate.style";
+
+interface TextDateProps {
+  type: "day" | "time";
+  values: string[]; // 날짜 or 시간의 리스트
+}
+
+function TextDate({ type, values }: TextDateProps) {
+  return (
+    <div>
+      {type === "day" && (
+        <div>
+          {values.map((day, index) => (
+            <Styled.Text key={`day-${index}`}>{day}</Styled.Text>
+          ))}
+        </div>
+      )}
+      {type === "time" && (
+        <div>
+          {values.map((time, index) => (
+            <Styled.Text key={`time-${index}`}>{time}</Styled.Text>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+export default TextDate;

--- a/src/components/common/TextDate/TextDate.tsx
+++ b/src/components/common/TextDate/TextDate.tsx
@@ -4,6 +4,7 @@ interface TextDateProps {
   values: string[]; // 날짜 or 시간의 시작 및 종료
 }
 
+// 일정/투두 리스트에서 시간,날짜 출력
 function TextDate({ values }: TextDateProps) {
   return (
     <Styled.TextContainer>

--- a/src/components/common/TodoList/TodoItem.stories.tsx
+++ b/src/components/common/TodoList/TodoItem.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import TodoItem from "@/components/common/TodoList/TodoItem";
+
+const meta = {
+  // 스토리북 경로 - 파일 경로와 동일하게 설정하는 것이 좋을 것 같습니다.
+  title: "components/common/TodoList/TodoItem",
+  component: TodoItem,
+  parameters: {
+    // 스토리북 캔버스에 표시되는 위치
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "이 컴포넌트는 카테고리 리스트에서 보여주는 색상입니다. 원 모양처럼 안 보이지만 원 모양으로 제작되어 있습니다.",
+      },
+    },
+  },
+} satisfies Meta<typeof TodoItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 스토리
+export const Default: Story = {
+  args: {
+    values: [],
+    color: "#EBFFE1",
+    todo: "기말고사",
+    isComplete: false,
+    isMember: [],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "기본 테스트 컴포넌트입니다.",
+      },
+    },
+  },
+};
+
+export const AddData: Story = {
+  args: {
+    values: ["10 : 00", "10 : 50"],
+    color: "#EBFFE1",
+    todo: "기말고사",
+    isComplete: false,
+    isMember: [
+      { name: "가을", process: true },
+      { name: "영서", process: false },
+      { name: "보라", process: false },
+      { name: "미래", process: true },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "값이 들어온 경우",
+      },
+    },
+  },
+};

--- a/src/components/common/TodoList/TodoItem.style.tsx
+++ b/src/components/common/TodoList/TodoItem.style.tsx
@@ -1,0 +1,58 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  width: calc(100% - 2rem);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 5px;
+  margin: 0 auto;
+  padding: 0.5rem;
+  border-bottom: 1px solid #97cdbd;
+`;
+
+export const ExplanContainer = styled.div`
+  min-width: 50%;
+  display: flex;
+  flex: 1;
+  gap: 7px;
+  align-items: center;
+  overflow: hidden;
+`;
+
+export const TodoText = styled.p<{ isChecked: boolean }>`
+  width: 100%;
+  font-size: 1rem;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  word-break: break-all;
+  text-decoration: ${(props) => (props.isChecked ? "line-through" : "none")};
+`;
+
+export const SetContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 7px;
+`;
+
+export const AssignWrapper = styled.div`
+  width: 80px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  word-break: break-all;
+`;
+
+export const AssignPeople = styled.span<{ isMemDone: boolean }>`
+  font-size: var(--font-size-small);
+
+  color: ${(props) => (props.isMemDone ? "#92C8B8" : "#B1B1B1")};
+`;
+
+export const CheckboxCustom = styled.input.attrs({ type: "checkbox" })`
+  width: 17px;
+  height: 17px;
+  border: 1px solid #97cdbd;
+  accent-color: #97cdbd; // 체크 됐을 때의 색상
+`;

--- a/src/components/common/TodoList/TodoItem.tsx
+++ b/src/components/common/TodoList/TodoItem.tsx
@@ -1,0 +1,56 @@
+import * as Styled from "./TodoItem.style";
+import useTodoItem from "@/hooks/useTodoItem";
+import TextDate from "../TextDate/TextDate";
+import ListBar from "../ListBar/ListBar";
+
+interface GroupMember {
+  name: string; // 이름
+  process: boolean; // todo 완료 상태
+}
+interface TodoItemProps {
+  values: string[];
+  color: string;
+  todo: string;
+  isComplete: boolean;
+  isMember: GroupMember[];
+}
+function TodoItem({
+  values = [],
+  color = "#EBFFE1",
+  todo = "기말고사기말고사기말고사기말기말고사기말고사기말고사기말",
+  isComplete = false,
+  isMember = [],
+}: TodoItemProps) {
+  const { isChecked, toggleChecked } = useTodoItem({ isComplete });
+
+  return (
+    <Styled.Wrapper>
+      <Styled.ExplanContainer>
+        {values.length > 0 ? <TextDate values={values} /> : ""}
+        <ListBar color={color} />
+        <Styled.TodoText isChecked={isChecked}>{todo}</Styled.TodoText>
+      </Styled.ExplanContainer>
+      <Styled.SetContainer>
+        {isMember.length ? (
+          <Styled.AssignWrapper>
+            {isMember.map((people: GroupMember) => (
+              <Styled.AssignPeople isMemDone={people.process}>
+                {people.name}{" "}
+              </Styled.AssignPeople>
+            ))}
+          </Styled.AssignWrapper>
+        ) : (
+          ""
+        )}
+        <Styled.CheckboxCustom
+          type="checkbox"
+          checked={isChecked}
+          onChange={toggleChecked}
+        />
+        <span>(아이콘)</span>
+      </Styled.SetContainer>
+    </Styled.Wrapper>
+  );
+}
+
+export default TodoItem;

--- a/src/hooks/useCircleInput.ts
+++ b/src/hooks/useCircleInput.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-const useCircleInput = () => {
+function useCircleInput() {
   const [selectedColor, setSelectedColor] = useState<string>("#000000"); // 상태 공유
 
   // 현재는 값을 확인하기 위해 onChange로 해두었는데,
@@ -19,6 +19,6 @@ const useCircleInput = () => {
   };
 
   return { selectedColor, handleChange };
-};
+}
 
 export default useCircleInput;

--- a/src/hooks/useTodoItem.ts
+++ b/src/hooks/useTodoItem.ts
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+interface UseTodoItemProps {
+  isComplete: boolean;
+}
+
+function useTodoItem({ isComplete }: UseTodoItemProps) {
+  const [isChecked, setIsChecked] = useState(isComplete);
+
+  const toggleChecked = () => {
+    setIsChecked((prev: boolean) => !prev);
+  };
+
+  return { isChecked, toggleChecked };
+}
+
+export default useTodoItem;


### PR DESCRIPTION
## 구현 요약
- 투두와 일정을 컴포넌트를 분리해서 제작했습니다.
- 투두 컴포넌트는 개인과 그룹을 하나로 관리하고 있습니다.

- 투두를 완료하고 체크를 누르면 취소선이 나타나게 했습니다.

### 연관 이슈

-  close #27 

## 체크 리스트

- [x] merge 브랜치 확인했나요?
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
