### PR TITLE
refactor: 인터페이스 분리 및 코드 수정

### DIFF
--- a/src/components/common/DateInput/DateInput.style.ts
+++ b/src/components/common/DateInput/DateInput.style.ts
@@ -7,18 +7,18 @@ export const InputContainer = styled.div`
   align-items: center;
 `;
 
-export const DateInput = styled.input`
+export const InputDate = styled.input`
   width: 100%;
   box-sizing: border-box;
   border: none;
-  border-bottom: 1px solid var(--color-gray-light);
+  border-bottom: 1px solid var(--color-primary);
   padding: 0.5rem;
   color: var(--color-black);
   outline: none;
   transition: 0.3s;
 
   &:focus {
-    border-bottom: 1px solid var(--color-primary);
+    border-bottom: 1px solid var(--color-primary-hover);
   }
 
   &::placeholder {

--- a/src/components/common/DateInput/DateInput.tsx
+++ b/src/components/common/DateInput/DateInput.tsx
@@ -4,12 +4,7 @@ import { ko } from "date-fns/locale";
 import "react-datepicker/dist/react-datepicker.css";
 import * as Style from "./DateInput.style";
 import "./DateInput.css";
-
-interface DateProps {
-  defaultDate: string; // 시작 날짜와 종료 날짜의 기본값 (메인페이지 달력 날짜 기준으로 받아와야함)
-  onChange: (startDate: Date | null, endDate: Date | null) => void; // 날짜 변경될 때마다 호출해서 변경된 날짜 전달
-  withEndDate?: boolean; // 종료날짜 입력 옵션
-}
+import { DateProps } from "@/types/input.types";
 
 function DateInput({ defaultDate, onChange, withEndDate }: DateProps) {
   const initialDate = new Date(defaultDate);
@@ -40,8 +35,7 @@ function DateInput({ defaultDate, onChange, withEndDate }: DateProps) {
             required
             selected={startDate}
             onChange={handleStartDateChange}
-            customInput={<Style.DateInput />}
-            popperPlacement="bottom-end"
+            customInput={<Style.InputDate />}
           />
         </div>
       </>
@@ -55,9 +49,8 @@ function DateInput({ defaultDate, onChange, withEndDate }: DateProps) {
               selected={endDate}
               onChange={handleEndDateChange}
               minDate={startDate || new Date()}
-              customInput={<Style.DateInput />}
+              customInput={<Style.InputDate />}
               placeholderText="종료 날짜 (선택)"
-              popperPlacement="bottom-end"
             />
           </div>
         </>

--- a/src/components/common/SelectList/Category/CategorySelect.style.ts
+++ b/src/components/common/SelectList/Category/CategorySelect.style.ts
@@ -36,14 +36,14 @@ export const customsControl: (
   ...provided,
   border: "none",
   borderBottom: state.isFocused
-    ? "1px solid var(--color-primary)"
-    : "1px solid var(--color-gray-light)",
+    ? "1px solid var(--color-primary-hover)"
+    : "1px solid var(--color-primary)",
   boxShadow: "none",
   minHeight: "40px",
   borderRadius: "0",
   transition: " 0.3s ease",
   "&:hover": {
-    borderColor: "var(--color-primary)",
+    borderColor: "var(--color-primary-hover)",
   },
 });
 

--- a/src/components/common/SelectList/Category/CategorySelect.tsx
+++ b/src/components/common/SelectList/Category/CategorySelect.tsx
@@ -1,16 +1,7 @@
 import Select, { SingleValue } from "react-select";
 import * as Style from "./CategorySelect.style";
 import Circle from "../../Circle/Circle";
-
-export interface OptionType {
-  name: string; // 카테고리 이름 name
-  color: string; // 카테고리 색상 color
-}
-
-interface CategoryProps {
-  options: OptionType[];
-  onCategoryChange: (selectedCategory: OptionType | null) => void;
-}
+import { OptionType, CategoryProps } from "@/types/select.types";
 
 const CategoryValue = (props: { data: OptionType }) => {
   const { data } = props;

--- a/src/components/common/SelectList/Group/GroupSelect.style.ts
+++ b/src/components/common/SelectList/Group/GroupSelect.style.ts
@@ -39,14 +39,14 @@ export const customControl: (
   ...provided,
   border: "none",
   borderBottom: state.isFocused
-    ? "1px solid var(--color-primary)"
-    : "1px solid var(--color-gray-light)",
+    ? "1px solid var(--color-primary-hover)"
+    : "1px solid var(--color-primary)",
   boxShadow: "none",
   minHeight: "40px",
   borderRadius: "0",
   transition: "0.3s ease",
   "&:hover": {
-    borderBottom: "1px solid var(--color-primary)",
+    borderBottom: "1px solid var(--color-primary-hover)",
   },
 });
 

--- a/src/components/common/SelectList/Group/GroupSelect.tsx
+++ b/src/components/common/SelectList/Group/GroupSelect.tsx
@@ -1,18 +1,7 @@
 import Select from "react-select";
 import * as Style from "./GroupSelect.style";
 import ProfileImg from "../../ProfileImg/ProfileImg";
-
-export interface GroupMember {
-  value: string; // 유저 id
-  label: string; // 유저 nickname
-  profileImage: string; // 유저 image_url
-}
-
-interface GroupProps {
-  groupMembers: GroupMember[];
-  selectedMembers: GroupMember[];
-  onMemberChange: (selectedMembers: GroupMember[]) => void;
-}
+import { GroupMember, GroupProps } from "@/types/select.types";
 
 function GroupSelect({
   groupMembers,

--- a/src/components/common/TextInput/TextInput.stories.tsx
+++ b/src/components/common/TextInput/TextInput.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import TextInput from "./TextInput";
 
 const meta: Meta<typeof TextInput> = {
-  title: "Components/TextInput",
+  title: "Components/common/TextInput/TextInput",
   component: TextInput,
   tags: ["autodocs"],
   args: {

--- a/src/components/common/TextInput/TextInput.style.ts
+++ b/src/components/common/TextInput/TextInput.style.ts
@@ -1,6 +1,4 @@
-// TextInput.style.ts
 import styled from "styled-components";
-import "@/index.css";
 
 export const Label = styled.label`
   display: block;
@@ -13,20 +11,21 @@ export const Label = styled.label`
 export const Input = styled.input`
   width: 100%;
   border: none;
-  border-bottom: 1px solid var(--color-gray-light);
+  border-bottom: 1px solid var(--color-primary);
   padding: 0.5rem;
   font-size: var(--font-size-medium);
   color: var(--color-black);
   outline: none;
 
   &:focus {
-    border-bottom: 1px solid var(--color-primary);
+    border-bottom: 1px solid var(--color-primary-hover);
   }
 
   &::placeholder {
     color: var(--color-gray-light);
   }
 `;
+
 export const ErrorMessage = styled.p`
   color: #ff7e7e;
   font-size: var(--font-size-small);

--- a/src/components/common/TextInput/TextInput.tsx
+++ b/src/components/common/TextInput/TextInput.tsx
@@ -1,17 +1,8 @@
 import * as Style from "./TextInput.style";
 import { useState } from "react";
+import { TextInputProps } from "@/types/input.types";
 
-interface TextInputProps {
-  name: string;
-  type: "text" | "email" | "password";
-  label?: string;
-  placeholder?: string;
-  required: boolean;
-  maxLength: number;
-  minLength: number;
-}
-
-export default function TextInput({
+function TextInput({
   name, // 입력 필드 이름
   type = "text", // 입력 필드 형식
   label, // 입력 필드 라벨
@@ -19,6 +10,8 @@ export default function TextInput({
   required = true, // 필수 입력
   maxLength = 20, // 최대 입력 길이
   minLength = 2, // 최소 입력 길이
+  value,
+  onChange,
 }: TextInputProps) {
   const [isEmailValid, setIsEmailValid] = useState(true);
   const [isPasswordValid, setIsPasswordValid] = useState(true);
@@ -31,16 +24,19 @@ export default function TextInput({
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    onChange(inputValue); // 상위 컴포넌트로 상태 전달
+
     if (type === "email") {
       // 이메일 유효성 검사
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-      setIsEmailValid(emailRegex.test(e.target.value));
+      setIsEmailValid(emailRegex.test(inputValue));
     }
 
     if (type === "password") {
       // 비밀번호 유효성 검사
       const passwordRegex = /^(?=.*\d)(?=.*[\W_]).{8,}$/;
-      setIsPasswordValid(passwordRegex.test(e.target.value));
+      setIsPasswordValid(passwordRegex.test(inputValue));
     }
   };
 
@@ -49,6 +45,7 @@ export default function TextInput({
       {label && <Style.Label htmlFor={name}>{label}</Style.Label>}
       <Style.Input
         id={name}
+        name={name}
         type={type}
         placeholder={placeholder}
         required={required}
@@ -56,6 +53,7 @@ export default function TextInput({
         minLength={minLength}
         onChange={handleChange}
         onInvalid={handleInvalid}
+        value={value}
       />
       {type === "email" && !isEmailValid && (
         <Style.ErrorMessage>
@@ -71,3 +69,4 @@ export default function TextInput({
     </>
   );
 }
+export default TextInput;

--- a/src/components/common/TimeInput/TimeInput.stories.tsx
+++ b/src/components/common/TimeInput/TimeInput.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import TimeInput from "./TimeInput";
 
 const meta = {
-  title: "Components/TimeInput",
+  title: "Components/common/TimeInput/TimeInput",
   component: TimeInput,
   parameters: {
     docs: {

--- a/src/components/common/TimeInput/TimeInput.style.ts
+++ b/src/components/common/TimeInput/TimeInput.style.ts
@@ -10,14 +10,14 @@ export const Container = styled.div`
 export const StyledTimeInput = styled.input.attrs({ type: "time" })`
   width: 100%;
   border: none;
-  border-bottom: 1px solid var(--color-gray-light);
+  border-bottom: 1px solid var(--color-primary);
   padding: 0.5rem;
   font-size: var(--font-size-medium);
   color: var(--color-black);
   outline: none;
 
   &:focus {
-    border-bottom: 1px solid var(--color-primary);
+    border-bottom: 1px solid var(--color-primary-hover);
   }
 
   &::placeholder {

--- a/src/components/common/TimeInput/TimeInput.tsx
+++ b/src/components/common/TimeInput/TimeInput.tsx
@@ -1,12 +1,6 @@
 import { useState } from "react";
 import * as Style from "./TimeInput.style";
-
-interface TimeInputProps {
-  defaultStartTime?: string; // default 시작시간
-  defaultEndTime?: string; // default 종료시간
-  withEndTime?: boolean; // 종료시간 옵션 (true: 사용, false: 사용하지 않음)
-  onChange: (startTime: string, endTime?: string) => void; // 시간 바뀔때마다 호출해서 바뀐 시간 전달
-}
+import { TimeInputProps } from "@/types/input.types";
 
 function TimeInput({
   defaultStartTime = "09:00",
@@ -42,18 +36,22 @@ function TimeInput({
     <Style.Container>
       <Style.StyledTimeInput
         id="start-time"
+        name="startTime"
         type="time"
         value={startTime}
         onChange={handleStartTimeChange}
+        required
       />
       {withEndTime && (
         <>
           →
           <Style.StyledTimeInput
             id="end-time"
+            name="endTime"
             type="time"
             value={endTime || ""}
             onChange={handleEndTimeChange}
+            required={withEndTime}
           />
         </>
       )}

--- a/src/types/input.types.ts
+++ b/src/types/input.types.ts
@@ -1,0 +1,27 @@
+// 텍스트 입력 interface (기본 텍스트, 이메일, 비밀번호)
+export interface TextInputProps {
+  name: string; // 입력 필드 이름
+  type: "text" | "email" | "password"; // 입력 필드 형식
+  label?: string; // 입력 필드 라벨
+  placeholder?: string; // 입력 필드 플레이스홀더
+  required?: boolean; // 필수 입력 여부
+  maxLength?: number; // 최대 입력 길이
+  minLength?: number; // 최소 입력 길이
+  value: string; // 입력 필드의 현재 값
+  onChange: (value: string) => void; // 상위 컴포넌트로 상태를 전달할 함수
+}
+
+// 시간 입력 interface (시작, 종료 시간 입력)
+export interface TimeInputProps {
+  defaultStartTime?: string; // default 시작시간
+  defaultEndTime?: string; // default 종료시간
+  withEndTime?: boolean; // 종료시간 옵션 (true: 사용, false: 사용하지 않음)
+  onChange: (startTime: string, endTime?: string) => void; // 시간 바뀔때마다 호출해서 바뀐 시간 전달
+}
+
+// 날짜 입력 interface
+export interface DateProps {
+  defaultDate: string; // 시작 날짜와 종료 날짜의 기본값 (메인페이지 달력 날짜 기준으로 받아와야함)
+  onChange: (startDate: Date | null, endDate: Date | null) => void; // 날짜 변경될 때마다 호출해서 변경된 날짜 전달
+  withEndDate?: boolean; // 종료날짜 입력 옵션
+}

--- a/src/types/select.types.ts
+++ b/src/types/select.types.ts
@@ -1,0 +1,25 @@
+// 그룹원 선택 드롭다운 interface
+export interface GroupMember {
+  value: string; // 유저 id
+  label: string; // 유저 nickname
+  profileImage: string; // 유저 image_url
+}
+
+// 선택한 팀원이 변경될 때마다 props 주고받기
+export interface GroupProps {
+  groupMembers: GroupMember[]; // 그룹원 유저 데이터
+  selectedMembers: GroupMember[]; // 선택된 그룹원 유저 데이터
+  onMemberChange: (selectedMembers: GroupMember[]) => void;
+}
+
+// 카테고리 선택 드롭다운 interface
+export interface OptionType {
+  name: string; // 카테고리 이름 name
+  color: string; // 카테고리 색상 color
+}
+
+// 선택한 카테고리 바뀔 때마다 props
+export interface CategoryProps {
+  options: OptionType[]; // 카테고리 데이터
+  onCategoryChange: (selectedCategory: OptionType | null) => void;
+}


### PR DESCRIPTION
## 구현 요약
### input 입력 등에 쓰이는 interface들을 types 폴더 안에 정리해뒀습니다 

`input.types.ts` - TextInput, TimeInput, DateInput 컴포넌트 인터페이스
`select.types.ts` - GroupSelect, CategorySelect 컴포넌트 인터페이스


### TextInput 컴포넌트에 onChange 함수 추가

아래 코드처럼 입력해서 사용하시면 됩니다 
name, type, value, onChange 만 필수 입력
나머지는 옵션으로 추가했습니다


```typescript
  const [textInputValue, setTextInputValue] = useState("");

  const handleInputChange = (value: string) => {
    setTextInputValue(value);
  };

``` 
```html
<TextInput
  name="input"
  type="text"
  label="내용"  
  placeholder="내용을 입력하세요" 
  required={true}  
  maxLength={20} 
  minLength={2} 
  value={textInputValue}  
  onChange={handleInputChange}   
/>

``` 

추가적으로 css는 입력 border-bottom 부분 primary 컬러로 수정했습니다

### 연관 이슈

- ex) close #47 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
