### PR TITLE
feat: header 구현 및 루트레이아웃 수정

### DIFF
--- a/src/components/layout/Header/Header.style.ts
+++ b/src/components/layout/Header/Header.style.ts
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+import { NavLink } from "react-router-dom";
+
+export const HeaderDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  max-width: var(--breakpoint-mobile);
+  padding: 1rem;
+  z-index: 1000;
+  background-color: #ffffff;
+  position: fixed;
+  box-sizing: border-box;
+  transition:
+    border-bottom 0.3s ease,
+    box-shadow 0.3s ease;
+`;
+
+export const StyledNavLink = styled(NavLink)`
+  text-decoration: none;
+  color: var(--color-primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: color 0.3s ease;
+
+  &:hover {
+    color: var(--color-primary-hover);
+  }
+`;
+
+export const IconWrapper = styled.div`
+  color: var(--color-primary);
+  transition: color 0.3s ease;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--color-primary-hover);
+  }
+`;

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,0 +1,39 @@
+import BackIcon from "@/assets/icons/back.svg?react";
+import AlarmIcon from "@/assets/icons/alarm.svg?react";
+import * as Style from "./Header.style";
+import { useLocation, useNavigate } from "react-router-dom";
+
+function Header() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // 로고를 보여줄 경로 리스트
+  const pathLogo = ["/", "/main", "/group", "/chat", "/mypage"];
+
+  // 경로에 따라 로고를 보여줄지 결정
+  const showLogo = pathLogo.includes(location.pathname);
+
+  const handleBackClick = () => {
+    navigate(-1); // 이전 페이지로 이동
+  };
+  return (
+    <Style.HeaderDiv>
+      {showLogo ? (
+        <Style.StyledNavLink to="/main">로고</Style.StyledNavLink>
+      ) : (
+        <Style.IconWrapper onClick={handleBackClick}>
+          <BackIcon
+            width={25}
+            height={25}
+            fill="currentColor"
+            stroke="currentColor"
+          />
+        </Style.IconWrapper>
+      )}
+      <Style.StyledNavLink to="/notifications">
+        <AlarmIcon width={24} height={24} fill="none" stroke="currentColor" />
+      </Style.StyledNavLink>
+    </Style.HeaderDiv>
+  );
+}
+export default Header;

--- a/src/components/layout/RootLayout/RootLayout.tsx
+++ b/src/components/layout/RootLayout/RootLayout.tsx
@@ -1,10 +1,11 @@
 import { Outlet } from "react-router-dom";
 import * as Style from "./RootLayout.style";
 import NavBar from "../NavBar/NavBar";
+import Header from "../Header/Header";
 function RootLayout() {
   return (
     <Style.RootLayoutWrapper>
-      <header>Header</header>
+      <Header />
       <main>
         <Outlet />
       </main>


### PR DESCRIPTION
## 구현 요약
### 상단 헤더 구현 및 루트레이아웃 수정

<img width="415" alt="스크린샷 2024-11-29 오전 11 00 34" src="https://github.com/user-attachments/assets/6eabd385-5d66-48da-9d1e-a859b4183125">

<img width="410" alt="스크린샷 2024-11-29 오전 11 01 42" src="https://github.com/user-attachments/assets/0c1185cf-e290-4039-a5b4-661bdfe46056">

메인페이지, 그룹페이지, 챗봇페이지, 마이페이지 에서는 로고를 보여주고
나머지 페이지에서는 뒤로가기 버튼을 보여줍니다

루트레이아웃에 헤더를 추가해서 모든 페이지에서 확인 가능합니다 !

### 연관 이슈

- ex) close #53 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
