### PR TITLE
design: 회원가입 페이지 퍼블리싱

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -11,11 +11,16 @@ interface IProps {
     | "whiteSmall"
     | "whiteMicro";
   isHoverEffect?: boolean;
+  type: "button" | "submit" | "reset";
 }
 
-function Button({ children, buttonType, isHoverEffect }: IProps) {
+function Button({ children, buttonType, isHoverEffect, type }: IProps) {
   return (
-    <S.Button $buttonType={buttonType} $isHoverEffect={isHoverEffect}>
+    <S.Button
+      $buttonType={buttonType}
+      $isHoverEffect={isHoverEffect}
+      type={type}
+    >
       {children}
     </S.Button>
   );

--- a/src/components/common/TextInput/TextInput.tsx
+++ b/src/components/common/TextInput/TextInput.tsx
@@ -41,7 +41,7 @@ function TextInput({
   };
 
   return (
-    <>
+    <div>
       {label && <Style.Label htmlFor={name}>{label}</Style.Label>}
       <Style.Input
         id={name}
@@ -66,7 +66,7 @@ function TextInput({
           합니다.
         </Style.ErrorMessage>
       )}
-    </>
+    </div>
   );
 }
 export default TextInput;

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -8,7 +8,7 @@ function Header() {
   const navigate = useNavigate();
 
   // 로고를 보여줄 경로 리스트
-  const pathLogo = ["/", "/main", "/group", "/chat", "/mypage"];
+  const pathLogo = ["/", "/main", "/group", "/chat", "/mypage", "/signup"];
 
   // 경로에 따라 로고를 보여줄지 결정
   const showLogo = pathLogo.includes(location.pathname);

--- a/src/components/layout/NavBar/NavBar.tsx
+++ b/src/components/layout/NavBar/NavBar.tsx
@@ -6,55 +6,73 @@ import ProfileIcon from "@/assets/icons/profile.svg?react";
 import * as Style from "./NavBar.style";
 
 function NavBar() {
+  // 네브바를 보여주지 않을 경로 리스트
+  const pathNav = ["/signup"];
+  const noNav = pathNav.includes(location.pathname);
+
   return (
-    <Style.Nav>
-      <Style.NavItem>
-        <NavLink
-          to="/main"
-          className={({ isActive }) => (isActive ? "active" : "")}
-        >
-          <HomeIcon width={24} height={24} fill="none" stroke="currentColor" />
-          <span>홈</span>
-        </NavLink>
-      </Style.NavItem>
-      <Style.NavItem>
-        <NavLink
-          to="/group"
-          className={({ isActive }) => (isActive ? "active" : "")}
-        >
-          <GroupIcon width={24} height={24} fill="none" stroke="currentColor" />
-          <span>그룹</span>
-        </NavLink>
-      </Style.NavItem>
-      <Style.NavItem>
-        <NavLink
-          to="/chat"
-          className={({ isActive }) => (isActive ? "active" : "")}
-        >
-          <ChatbotIcon
-            width={24}
-            height={24}
-            fill="none"
-            stroke="currentColor"
-          />
-          <span>챗봇</span>
-        </NavLink>
-      </Style.NavItem>
-      <Style.NavItem>
-        <NavLink
-          to="/mypage"
-          className={({ isActive }) => (isActive ? "active" : "")}
-        >
-          <ProfileIcon
-            width={24}
-            height={24}
-            fill="none"
-            stroke="currentColor"
-          />
-          <span>프로필</span>
-        </NavLink>
-      </Style.NavItem>
-    </Style.Nav>
+    <>
+      {!noNav && (
+        <Style.Nav>
+          <Style.NavItem>
+            <NavLink
+              to="/main"
+              className={({ isActive }) => (isActive ? "active" : "")}
+            >
+              <HomeIcon
+                width={24}
+                height={24}
+                fill="none"
+                stroke="currentColor"
+              />
+              <span>홈</span>
+            </NavLink>
+          </Style.NavItem>
+          <Style.NavItem>
+            <NavLink
+              to="/group"
+              className={({ isActive }) => (isActive ? "active" : "")}
+            >
+              <GroupIcon
+                width={24}
+                height={24}
+                fill="none"
+                stroke="currentColor"
+              />
+              <span>그룹</span>
+            </NavLink>
+          </Style.NavItem>
+          <Style.NavItem>
+            <NavLink
+              to="/chat"
+              className={({ isActive }) => (isActive ? "active" : "")}
+            >
+              <ChatbotIcon
+                width={24}
+                height={24}
+                fill="none"
+                stroke="currentColor"
+              />
+              <span>챗봇</span>
+            </NavLink>
+          </Style.NavItem>
+          <Style.NavItem>
+            <NavLink
+              to="/mypage"
+              className={({ isActive }) => (isActive ? "active" : "")}
+            >
+              <ProfileIcon
+                width={24}
+                height={24}
+                fill="none"
+                stroke="currentColor"
+              />
+              <span>프로필</span>
+            </NavLink>
+          </Style.NavItem>
+        </Style.Nav>
+      )}
+    </>
   );
 }
 

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -1,0 +1,61 @@
+import { useState } from "react";
+
+interface FormData {
+  name: string;
+  email: string;
+  password: string;
+  checkPwd: string;
+  profileImage: File | null;
+  profileImagePreview: string | null;
+}
+
+function useSignupForm() {
+  const [formData, setFormData] = useState<FormData>({
+    name: "",
+    email: "",
+    password: "",
+    checkPwd: "",
+    profileImage: null,
+    profileImagePreview: null,
+  });
+
+  // input onChange 함수
+  const handleChange = (fieldName: string) => (value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [fieldName]: value,
+    }));
+  };
+
+  // 이미지 미리보기 및 이미지 데이터 (이미지 데이터는 추후 수정 필요)
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]; // e.target은 HTMLInputElement 타입
+    if (file) {
+      setFormData((prev) => ({
+        ...prev,
+        profileImage: file,
+        profileImagePreview: URL.createObjectURL(file), // 미리보기 URL 생성
+      }));
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (formData.password !== formData.checkPwd) {
+      alert("비밀번호가 일치하지 않습니다.");
+      return;
+    } else {
+      // 여기에 formData를 백엔드로 보내는 로직 추가
+      console.log("전송 Form Data:", formData);
+    }
+  };
+
+  return {
+    formData,
+    handleChange,
+    handleImageChange,
+    handleSubmit,
+  };
+}
+
+export default useSignupForm;

--- a/src/pages/signup/SignupPage.style.tsx
+++ b/src/pages/signup/SignupPage.style.tsx
@@ -10,7 +10,7 @@ export const Wrapper = styled.div`
   justify-content: space-between;
   gap: 60px;
   padding-top: 80px;
-  padding-bottom: 80px;
+  padding-bottom: 20px;
 `;
 
 export const Form = styled.form`

--- a/src/pages/signup/SignupPage.style.tsx
+++ b/src/pages/signup/SignupPage.style.tsx
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  width: 339px;
+  height: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  gap: 60px;
+  padding-top: 80px;
+  padding-bottom: 80px;
+`;
+
+export const Form = styled.form`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+`;
+
+export const Label = styled.label`
+  display: flex;
+  justify-content: center;
+  cursor: pointer;
+`;
+
+export const FilePreview = styled.div`
+  width: 8rem;
+  height: 8rem;
+  background-color: #c9c9c9;
+  border-radius: var(--border-radius-circle);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+`;
+
+export const Img = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: var(--border-radius-circle);
+  object-fit: cover;
+`;
+
+export const InputFile = styled.input.attrs({ type: "file" })`
+  display: none;
+`;

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -1,5 +1,95 @@
+import useSignupForm from "@/hooks/useSignupForm";
+import * as Styled from "./SignupPage.style";
+import TextInput from "@/components/common/TextInput/TextInput";
+import Button from "@/components/common/Button/Button";
+import Camera from "@/assets/icons/Camera.svg?react";
+
 function SignupPage() {
-  return <div>SignupPage</div>;
+  const { formData, handleChange, handleImageChange, handleSubmit } =
+    useSignupForm();
+
+  return (
+    <Styled.Wrapper>
+      <h1>회원 가입</h1>
+      {/* 프로필 이미지 업로드
+       ** 백엔드에서 s3 사용하는지 확인 필요
+       ** 그 전에는 경로만 보낸다고 했었음
+       ** 그거에 따라 이미지 업로드 보내는 방식이 달라짐 */}
+      <Styled.Form onSubmit={handleSubmit}>
+        <div>
+          <Styled.Label htmlFor="profileImage">
+            <Styled.FilePreview>
+              {formData.profileImagePreview ? (
+                <Styled.Img
+                  src={formData.profileImagePreview}
+                  alt="미리보기"
+                  style={{
+                    width: "100px",
+                    height: "100px",
+                    objectFit: "cover",
+                  }}
+                />
+              ) : (
+                <Camera width={"3.5rem"} height={"3.5rem"} stroke={"#fff"} />
+              )}
+            </Styled.FilePreview>
+          </Styled.Label>
+          <Styled.InputFile
+            type="file"
+            id="profileImage"
+            accept="image/*"
+            onChange={handleImageChange}
+          />
+        </div>
+
+        <TextInput
+          name="email"
+          type="email"
+          label="이메일"
+          placeholder="이메일을 입력해주세요"
+          required
+          maxLength={30}
+          minLength={4}
+          value={formData.email}
+          onChange={handleChange("email")}
+        />
+        <TextInput
+          name="password"
+          type="password"
+          label="비밀번호"
+          placeholder="비밀번호를 입력해주세요"
+          required
+          maxLength={16}
+          minLength={8}
+          value={formData.password}
+          onChange={handleChange("password")}
+        />
+        <TextInput
+          name="checkPwd"
+          type="password"
+          label="비밀번호 확인"
+          placeholder="비밀번호를 확인해주세요"
+          required
+          maxLength={10}
+          minLength={5}
+          value={formData.checkPwd}
+          onChange={handleChange("checkPwd")}
+        />
+        <TextInput
+          name="name"
+          type="text"
+          label="닉네임"
+          placeholder="2~10자로 입력해주세요"
+          required
+          maxLength={10}
+          minLength={2}
+          value={formData.name}
+          onChange={handleChange("name")}
+        />
+        <Button type="submit" children="가입" buttonType="primaryLarge" />
+      </Styled.Form>
+    </Styled.Wrapper>
+  );
 }
 
 export default SignupPage;


### PR DESCRIPTION
## 구현 요약

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/a3df5eab-3c6b-4bb4-a738-71632fd78614">

- 비빌번호와 비밀번호 확인이 일치하지 않으면 일단 `alert("비밀번호가 일치하지 않습니다.");` 처리 해두었습니다.
- `Header.tsx` 헤더를 뒤로가기가 아닌 로고가 나타나도록 했습니다. (알람은 없어져야할 것 같습니다.)
- `NavBar.tsx` 회원가입 페이지에선 네브바가 필요 없으므로 `Header.tsx`를 참고하여 비슷하게 처리했습니다.
- `Button.tsx`에 **type** props를 추가하여 클릭시 onSubmit 이벤트를 넣을 수 있도록 했습니다.
- `TextInput`에서 부모의 `<>~</>` 빈태그를 `<div>~</div>` 으로 수정했습니다. label과 input의 간격이 줄어들었습니다.

### 연관 이슈

이 부분을 제거하고 연관된 이슈를 아래와 같이 명시해 닫아주세요.

- ex) close #12

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
