### PR TITLE
feat: 카테고리 생성 페이지 개발

### DIFF
--- a/src/components/feature/CategoryList/CategoryList.style.ts
+++ b/src/components/feature/CategoryList/CategoryList.style.ts
@@ -1,0 +1,31 @@
+import styled from "styled-components";
+
+export const CategoryContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-primary);
+  width: 100%;
+  padding: 10px;
+  position: relative;
+  &:hover {
+    border-bottom: 1.25px solid var(--color-primary-hover);
+  }
+`;
+
+export const LeftSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`;
+
+export const RightIcon = styled.div`
+  margin-left: auto;
+  color: var(--color-gray-light);
+  transition: color 0.25s ease;
+  cursor: pointer;
+  position: relative;
+  &:hover {
+    color: var(--color-gray-dark);
+  }
+`;

--- a/src/components/feature/CategoryList/CategoryList.tsx
+++ b/src/components/feature/CategoryList/CategoryList.tsx
@@ -1,0 +1,118 @@
+import { useState, useEffect, useRef } from "react";
+import Circle from "@/components/common/Circle/Circle";
+import DotsIcon from "@/assets/icons/dots.svg?react";
+import * as Styled from "./CategoryList.style";
+import EditDeleteModal from "@/components/common/EditDeleteModal/EditDeleteModal";
+
+import { useNavigate } from "react-router-dom";
+import DeleteConfirm from "@/components/common/DeleteConfirm/DeleteConfirm";
+
+interface CategoryListProps {
+  categoryId: number;
+  color: string;
+  name: string;
+}
+
+function CategoryList({ categoryId, color, name }: CategoryListProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const iconRef = useRef<HTMLDivElement>(null);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+
+  const navigate = useNavigate();
+
+  // DotsIcon 클릭 시 모달 열기
+  const handleDotsClick = () => {
+    setIsModalOpen((prev) => !prev); // 현재 상태를 반전시켜 모달 열거나 닫기
+  };
+
+  // 모달 외부 클릭 시 모달 닫기 함수
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node) &&
+        iconRef.current &&
+        !iconRef.current.contains(event.target as Node)
+      ) {
+        setIsModalOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  // 수정 버튼 클릭 시 해당 카테고리 수정 페이지로 이동
+  const handleEditClick = () => {
+    navigate(`/categories/${categoryId}/edit`, {
+      state: { categoryId, color, name },
+    });
+    handleCloseModal();
+  };
+
+  // 삭제 버튼 클릭 시 삭제 확인 모달
+  const handleDeleteClick = () => {
+    handleCloseModal();
+    setIsDeleteConfirmOpen(true); // 삭제 확인 모달 열기
+  };
+
+  // 삭제 취소로 모달 닫기
+  const handleCloseDeleteConfirm = () => {
+    setIsDeleteConfirmOpen(false);
+  };
+
+  // 삭제 확인 모달에서 진짜 삭제
+  const handleConfirmDelete = () => {
+    setIsDeleteConfirmOpen(false);
+    // 실제 삭제 로직 추가
+  };
+
+  // 모달 닫기 함수
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  return (
+    <>
+      <Styled.CategoryContainer>
+        <Styled.LeftSection>
+          <Circle color={color} />
+          {name}
+        </Styled.LeftSection>
+        <Styled.RightIcon ref={iconRef} onClick={handleDotsClick}>
+          <DotsIcon
+            width={20}
+            height={20}
+            fill="currentColor"
+            stroke="currentColor"
+          />
+        </Styled.RightIcon>
+        {isModalOpen && (
+          <div
+            ref={modalRef}
+            style={{ position: "absolute", top: "100%", right: 0, zIndex: 999 }}
+          >
+            <EditDeleteModal
+              top={-10}
+              left={-55}
+              onClickEdit={handleEditClick}
+              onClickDelete={handleDeleteClick}
+            />
+          </div>
+        )}
+        {isDeleteConfirmOpen && (
+          <DeleteConfirm
+            text="정말로 삭제하시겠습니까?"
+            onClickCancel={handleCloseDeleteConfirm}
+            onClickDelete={handleConfirmDelete}
+          />
+        )}
+      </Styled.CategoryContainer>
+    </>
+  );
+}
+
+export default CategoryList;

--- a/src/pages/categories/CategoriesPage.style.ts
+++ b/src/pages/categories/CategoriesPage.style.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  padding: 6rem 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100vh;
+  box-sizing: border-box;
+`;
+
+export const CategoryListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex-grow: 1;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 2rem 0;
+`;

--- a/src/pages/categories/CategoriesPage.tsx
+++ b/src/pages/categories/CategoriesPage.tsx
@@ -1,5 +1,36 @@
+import Button from "@/components/common/Button/Button";
+import CategoryList from "@/components/feature/CategoryList/CategoryList";
+import * as Styled from "./CategoriesPage.style";
+import { Link } from "react-router-dom";
+
 function CategoriesPage() {
-  return <div>CategoriesPage</div>;
+  // 예시 데이터 나중에 삭제할 예정
+  const categories = [
+    { categoryId: 1, color: "red", name: "수학" },
+    { categoryId: 2, color: "blue", name: "과학" },
+    { categoryId: 3, color: "green", name: "영어" },
+    { categoryId: 4, color: "yellow", name: "역사" },
+  ];
+
+  return (
+    <Styled.Container>
+      <Styled.CategoryListContainer>
+        {categories.map((category) => (
+          <CategoryList
+            key={category.categoryId}
+            categoryId={category.categoryId}
+            color={category.color}
+            name={category.name}
+          />
+        ))}
+      </Styled.CategoryListContainer>
+      <Styled.ButtonWrapper>
+        <Link to="/categories/new">
+          <Button children="카테고리 만들기" buttonType="primaryLarge" />
+        </Link>
+      </Styled.ButtonWrapper>
+    </Styled.Container>
+  );
 }
 
 export default CategoriesPage;


### PR DESCRIPTION
## 구현 요약
### 카테고리 생성 페이지에 들어가는 리스트 컴포넌트로 구현

<img width="268" alt="스크린샷 2024-11-29 오후 3 22 24" src="https://github.com/user-attachments/assets/e953089f-1b5e-4ea7-a6be-444f7c59b7d4">

### 오른쪽 ... 버튼을 클릭했을 때 삭제 또는 수정 선택 모달

수정 선택 시에 해당 카테고리의 수정페이지로 이동
삭제를 선택하면 삭제 확인 모달창을 보여줌

<img width="330" alt="스크린샷 2024-11-29 오후 3 21 09" src="https://github.com/user-attachments/assets/dbd13cea-0e5d-4546-af9d-98ddaebeaa36">


### 삭제 확인 모달창

하단 내비게이션 바의 z인덱스를 수정해야함

<img width="328" alt="스크린샷 2024-11-29 오후 3 21 18" src="https://github.com/user-attachments/assets/1364b538-3dc7-4453-bbbc-03c0c9db239e">


### 카테고리 만들기 버튼을 클릭했을 때 현재는 Link를 통해 생성페이지로 이동


### 연관 이슈

- ex) close #55 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
