### PR TITLE
feat: 카테고리 생성 페이지 개발

### DIFF
--- a/src/components/common/Circle/Circle.style.tsx
+++ b/src/components/common/Circle/Circle.style.tsx
@@ -16,12 +16,12 @@ export const ColorWrapper = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 35px;
   align-items: center;
 `;
 
 export const ColorContainer = styled.div`
-  width: calc(100% - 4.5rem);
+  width: calc(100% - 3rem);
   display: flex;
   justify-content: space-between;
 `;
@@ -34,14 +34,14 @@ export const CircleBtn = styled.input.attrs({ type: "radio" })<{
   -moz-appearance: none;
   appearance: none;
 
-  width: 20px;
-  height: 20px;
-  border: 1px solid #ccc;
+  width: 42px;
+  height: 42px;
+
   border-radius: var(--border-radius-circle);
   outline: none;
   cursor: pointer;
   position: relative;
-  box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.25);
+  box-shadow: 0px 1.5px 4px rgba(0, 0, 0, 0.35);
   background-color: ${(props) => props.$color};
 
   /* 체크 됐을 때 내부 모습 */
@@ -57,18 +57,31 @@ export const CircleBtn = styled.input.attrs({ type: "radio" })<{
 `;
 
 export const CirclePicker = styled.input.attrs({ type: "color" })`
-  width: 20px;
-  height: 20px;
+  width: 42px;
+  height: 42px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   background-color: transparent;
-
+  border: none;
+  border-radius: 50%;
   padding: 0;
   cursor: pointer;
+  box-shadow: 0px 1.5px 4px rgba(0, 0, 0, 0.35);
+  &::-webkit-color-swatch-wrapper {
+    padding: 0;
+    border-radius: 50%;
+  }
 
-  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   &::-webkit-color-swatch {
     border: none;
+    border-radius: 50%;
   }
+`;
+export const Label = styled.label`
+  margin-top: 1rem;
+  font-size: var(--font-size-medium);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-black);
+  align-self: flex-start;
 `;

--- a/src/components/common/Circle/CircleInput.tsx
+++ b/src/components/common/Circle/CircleInput.tsx
@@ -6,6 +6,7 @@ function CircleInput() {
 
   return (
     <Styled.ColorWrapper>
+      <Styled.Label>색상</Styled.Label>
       <Styled.ColorContainer>
         {[
           "var(--color-category1)",

--- a/src/components/common/Circle/CircleInput.tsx
+++ b/src/components/common/Circle/CircleInput.tsx
@@ -1,8 +1,18 @@
 import * as Styled from "./Circle.style";
 import useCircleInput from "@/hooks/useCircleInput";
 
-function CircleInput() {
+interface CircleInputProps {
+  onChange: (value: string) => void; // 선택된 색상을 상위 컴포넌트로 전달
+}
+
+function CircleInput({ onChange }: CircleInputProps) {
   const { selectedColor, handleChange } = useCircleInput();
+
+  // 상태 변경 시 상위 컴포넌트로 전달
+  const handleCircleChange = (value: string) => {
+    handleChange(value); // 내부 상태 업데이트
+    onChange(value); // 상위 컴포넌트로 전달
+  };
 
   return (
     <Styled.ColorWrapper>
@@ -27,7 +37,7 @@ function CircleInput() {
                 .getPropertyValue(color.replace(/var\(|\)/g, "").trim())
                 .trim()
             }
-            onChange={(e) => handleChange(e.target.value)} // 상태 변경
+            onChange={(e) => handleCircleChange(e.target.value)} // 상태 변경
           />
         ))}
       </Styled.ColorContainer>
@@ -50,13 +60,13 @@ function CircleInput() {
                 .getPropertyValue(color.replace(/var\(|\)/g, "").trim())
                 .trim()
             }
-            onChange={(e) => handleChange(e.target.value)} // 상태 변경
+            onChange={(e) => handleCircleChange(e.target.value)} // 상태 변경
           />
         ))}
         <Styled.CirclePicker
           type="color"
           value={selectedColor} // 상태와 동기화
-          onChange={(e) => handleChange(e.target.value)} // color picker 선택
+          onChange={(e) => handleCircleChange(e.target.value)} // color picker 선택
         />
       </Styled.ColorContainer>
     </Styled.ColorWrapper>

--- a/src/components/layout/NavBar/NavBar.style.ts
+++ b/src/components/layout/NavBar/NavBar.style.ts
@@ -12,7 +12,7 @@ export const Nav = styled.nav`
   bottom: 0;
   width: 100%;
   max-width: var(--breakpoint-mobile);
-  z-index: 1000;
+  z-index: 100;
   box-sizing: border-box;
 `;
 

--- a/src/hooks/useCategoryForm.ts
+++ b/src/hooks/useCategoryForm.ts
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+interface FormData {
+  categoryName: string;
+  categoryColor: string;
+}
+
+const defaultColor = "var(--color-category1)";
+
+function useCategoryForm() {
+  const [formData, setFormData] = useState<FormData>({
+    categoryName: "",
+    categoryColor: defaultColor,
+  });
+
+  // TextInput 변경 핸들러
+  const handleTextInputChange = (value: string) => {
+    setFormData((prev) => ({ ...prev, categoryName: value }));
+  };
+
+  // CircleInput 변경 핸들러
+  const handleColorChange = (value: string) => {
+    setFormData((prev) => ({ ...prev, categoryColor: value }));
+  };
+
+  // 폼 제출 핸들러
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault(); // 기본 폼 제출 방지
+    console.log(formData);
+    // 나중에 API POST 코드 추가
+  };
+
+  return {
+    formData,
+    handleTextInputChange,
+    handleColorChange,
+    handleSubmit,
+  };
+}
+
+export default useCategoryForm;

--- a/src/hooks/useCircleInput.ts
+++ b/src/hooks/useCircleInput.ts
@@ -1,7 +1,12 @@
 import { useState } from "react";
 
 function useCircleInput() {
-  const [selectedColor, setSelectedColor] = useState<string>("#000000"); // 상태 공유
+  const defaultColor = "var(--color-category1)";
+  const [selectedColor, setSelectedColor] = useState<string>(
+    getComputedStyle(document.documentElement)
+      .getPropertyValue(defaultColor.replace(/var\(|\)/g, "").trim())
+      .trim()
+  );
 
   // 현재는 값을 확인하기 위해 onChange로 해두었는데,
   // submit으로 변경하거나 useState를 추가하면 될 것 같습니다.

--- a/src/index.css
+++ b/src/index.css
@@ -54,7 +54,7 @@ html {
   --color-category9: #e8e8e8;
 
   /* breakpoint */
-  --breakpoint-mobile: 768px;
+  --breakpoint-mobile: 600px;
 }
 
 /* 다크모드 */

--- a/src/pages/categories/new/CategoriesEditPage.style.ts
+++ b/src/pages/categories/new/CategoriesEditPage.style.ts
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+export const Container = styled.form`
+  padding: 6rem 2rem;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  box-sizing: border-box;
+  gap: 2rem;
+`;
+
+export const CategoryListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  flex-grow: 1;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 2rem 0;
+`;

--- a/src/pages/categories/new/CategoriesNewPage.tsx
+++ b/src/pages/categories/new/CategoriesNewPage.tsx
@@ -1,5 +1,39 @@
+import TextInput from "@/components/common/TextInput/TextInput";
+import * as Styled from "./CategoriesEditPage.style";
+import CircleInput from "@/components/common/Circle/CircleInput";
+import Button from "@/components/common/Button/Button";
+import useCategoryForm from "@/hooks/useCategoryForm";
+
 function CategoriesNewPage() {
-  return <div>CategoriesNewPage</div>;
+  const { formData, handleTextInputChange, handleColorChange, handleSubmit } =
+    useCategoryForm();
+
+  return (
+    <Styled.Container onSubmit={handleSubmit}>
+      <Styled.CategoryListContainer>
+        <TextInput
+          name="input"
+          type="text"
+          label="카테고리명"
+          placeholder="카테고리명을 입력해주세요"
+          required={true}
+          maxLength={20}
+          minLength={2}
+          value={formData.categoryName}
+          onChange={handleTextInputChange}
+        />
+        <CircleInput onChange={handleColorChange} />
+      </Styled.CategoryListContainer>
+      <Styled.ButtonWrapper>
+        <Button
+          children="카테고리 저장"
+          buttonType="primaryLarge"
+          type="submit"
+          isHoverEffect={true}
+        />
+      </Styled.ButtonWrapper>
+    </Styled.Container>
+  );
 }
 
 export default CategoriesNewPage;


### PR DESCRIPTION
## 구현 요약

### 카테고리 생성 페이지 개발
<img width="518" alt="스크린샷 2024-11-29 오후 8 50 13" src="https://github.com/user-attachments/assets/bb9ac35b-ed15-4b76-8e22-c2223ff817ad">


### 색상 선택 
- 색상 선택 부분 css 변경해서 꽉 찬 원으로 디자인 
- 색상 선택 default color 설정 var(--color-category1)

- 색상 선택 부분 props로 전달되도록 코드 수정
```typescript
interface CircleInputProps {
  onChange: (value: string) => void; // 선택된 색상을 상위 컴포넌트로 전달
}

  // 상태 변경 시 상위 컴포넌트로 전달
  const handleCircleChange = (value: string) => {
    handleChange(value); // 내부 상태 업데이트
    onChange(value); // 상위 컴포넌트로 전달
  };
``` 

### css
- 하단 내비게이션 바 z-index : 100으로 수정

- index.css 에서 width 사이즈 600px 으로 수정
```css
--breakpoint-mobile: 600px;
``` 


### 연관 이슈

- ex) close #56 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
