### PR TITLE
design: 로그인 페이지 퍼블리싱

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -8,7 +8,15 @@ function Header() {
   const navigate = useNavigate();
 
   // 로고를 보여줄 경로 리스트
-  const pathLogo = ["/", "/main", "/group", "/chat", "/mypage", "/signup"];
+  const pathLogo = [
+    "/",
+    "/main",
+    "/group",
+    "/chat",
+    "/mypage",
+    "/signup",
+    "/login",
+  ];
 
   // 경로에 따라 로고를 보여줄지 결정
   const showLogo = pathLogo.includes(location.pathname);

--- a/src/components/layout/NavBar/NavBar.tsx
+++ b/src/components/layout/NavBar/NavBar.tsx
@@ -7,7 +7,7 @@ import * as Style from "./NavBar.style";
 
 function NavBar() {
   // 네브바를 보여주지 않을 경로 리스트
-  const pathNav = ["/signup"];
+  const pathNav = ["/signup", "/login"];
   const noNav = pathNav.includes(location.pathname);
 
   return (

--- a/src/hooks/useLoginForm.ts
+++ b/src/hooks/useLoginForm.ts
@@ -1,0 +1,30 @@
+import { useState } from "react";
+
+interface FormData {
+  email: string;
+  password: string;
+}
+function useLoginForm() {
+  const [formData, setFormData] = useState<FormData>({
+    email: "",
+    password: "",
+  });
+
+  const handleChange = (name: string) => (value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    // 버튼 클릭시 입력 값 확인
+    console.log(formData);
+  };
+
+  return { formData, handleChange, handleSubmit };
+}
+
+export default useLoginForm;

--- a/src/pages/login/LoginPage.style.ts
+++ b/src/pages/login/LoginPage.style.ts
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  max-width: 339px;
+  padding-top: 80px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 0 auto;
+  gap: 30px;
+`;
+
+export const Name = styled.h1`
+  width: 100%;
+  color: var(--color-primary);
+  display: flex;
+  justify-content: flex-start;
+`;
+
+// 소개 멘트
+export const Explan = styled.p`
+  width: 95%;
+  display: flex;
+  justify-content: flex-start;
+`;
+
+// 폼
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+`;
+
+export const UserWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+  color: var(--color-gray-medium);
+
+  > a {
+    color: var(--color-gray-meidum);
+
+    &: hover {
+      text-decoration: underline;
+    }
+  }
+`;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,22 +1,25 @@
 import * as Styled from "./LoginPage.style";
+import { Link } from "react-router-dom";
+import useLoginForm from "@/hooks/useLoginForm";
 import TextInput from "@/components/common/TextInput/TextInput";
 import Button from "@/components/common/Button/Button";
-import { Link } from "react-router-dom";
 
 function LoginPage() {
+  const { formData, handleChange, handleSubmit } = useLoginForm();
+
   return (
     <Styled.Wrapper>
       <Styled.Name>J - AI</Styled.Name>
       <Styled.Explan>계획과 일정을 AI와 함께 시작해보세요!</Styled.Explan>
-      <Styled.Form>
+      <Styled.Form onSubmit={handleSubmit}>
         <TextInput
           name="email"
           label=""
           placeholder="이메일"
           required
           type="email"
-          value=""
-          onChange={(e) => console.log(e)}
+          value={formData.email}
+          onChange={handleChange("email")}
         />
         <TextInput
           name="password"
@@ -24,10 +27,10 @@ function LoginPage() {
           placeholder="비밀번호"
           required
           type="password"
-          value=""
-          onChange={(e) => console.log(e)}
+          value={formData.password}
+          onChange={handleChange("password")}
         />
-        <Button buttonType="primaryLarge" children="로그인" type="button" />
+        <Button buttonType="primaryLarge" children="로그인" type="submit" />
       </Styled.Form>
       <Styled.UserWrapper>
         <span>아이디 찾기</span>

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,5 +1,43 @@
+import * as Styled from "./LoginPage.style";
+import TextInput from "@/components/common/TextInput/TextInput";
+import Button from "@/components/common/Button/Button";
+import { Link } from "react-router-dom";
+
 function LoginPage() {
-  return <div>LoginPage</div>;
+  return (
+    <Styled.Wrapper>
+      <Styled.Name>J - AI</Styled.Name>
+      <Styled.Explan>계획과 일정을 AI와 함께 시작해보세요!</Styled.Explan>
+      <Styled.Form>
+        <TextInput
+          name="email"
+          label=""
+          placeholder="이메일"
+          required
+          type="email"
+          value=""
+          onChange={(e) => console.log(e)}
+        />
+        <TextInput
+          name="password"
+          label=""
+          placeholder="비밀번호"
+          required
+          type="password"
+          value=""
+          onChange={(e) => console.log(e)}
+        />
+        <Button buttonType="primaryLarge" children="로그인" type="button" />
+      </Styled.Form>
+      <Styled.UserWrapper>
+        <span>아이디 찾기</span>
+        <span>|</span>
+        <span>비밀번호 찾기</span>
+        <span>|</span>
+        <Link to="/signup">회원가입</Link>
+      </Styled.UserWrapper>
+    </Styled.Wrapper>
+  );
 }
 
 export default LoginPage;


### PR DESCRIPTION
## 구현 요약

- 로그인 페이지 퍼블리싱 진행했습니다.
<img width="1334" alt="image" src="https://github.com/user-attachments/assets/b89bb660-285b-4c16-b635-701e1baf7579">

- 값 입력 후 버튼 클릭 시 콘솔에 출력되도록 해두었습니다.

### 연관 이슈

-  close #68 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
