### PR TITLE
feat: 그룹 할일/일정의 생성/수정 페이지 제작

### DIFF
--- a/src/components/common/Circle/CircleInput.stories.tsx
+++ b/src/components/common/Circle/CircleInput.stories.tsx
@@ -14,6 +14,10 @@ const meta = {
       },
     },
   },
+  argTypes: {
+    defaultColor: { control: "color" },
+    onChange: { action: "onChange" },
+  },
 } satisfies Meta<typeof CircleInput>;
 
 export default meta;
@@ -21,12 +25,9 @@ type Story = StoryObj<typeof meta>;
 
 // 기본 스토리
 export const Default: Story = {
-  argTypes: {
-    backgroundColor: { control: "color" },
-  },
   args: {
-    title: "기본 테스트",
-    description: "색을 기본으로 아무 값이나 넣어둔 상태입니다.",
+    defaultColor: "black",
+    onChange: () => {},
   },
   parameters: {
     docs: {

--- a/src/components/common/SelectList/Group/GroupSelect.stories.tsx
+++ b/src/components/common/SelectList/Group/GroupSelect.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import GroupSelect from "@/components/common/SelectList/Group/GroupSelect";
-import { GroupMember } from "@/components/common/SelectList/Group/GroupSelect";
+import { GroupMember } from "@/types/select.types";
 
 const groupMembers: GroupMember[] = [
   {

--- a/src/components/common/SelectList/Group/GroupSelect.style.ts
+++ b/src/components/common/SelectList/Group/GroupSelect.style.ts
@@ -12,8 +12,8 @@ export const Placeholder = styled.div`
 `;
 
 export const Option = styled.div<{
-  isFocused: boolean;
-  isSelected: boolean;
+  $isFocused: boolean;
+  $isSelected: boolean;
 }>`
   display: flex;
   gap: 8px;
@@ -21,11 +21,11 @@ export const Option = styled.div<{
   padding: 10px;
   cursor: pointer;
   transition: background-color 0.2s ease;
-  background-color: ${(props) => (props.isFocused ? "#F6F7F8" : "white")};
+  background-color: ${(props) => (props.$isFocused ? "#F6F7F8" : "white")};
   color: ${(props) =>
-    props.isSelected ? "var(--color-primary-hover)" : "var(--color-black)"};
+    props.$isSelected ? "var(--color-primary-hover)" : "var(--color-black)"};
   font-weight: ${(props) =>
-    props.isSelected ? "var(  --font-weight-bold)" : "normal"};
+    props.$isSelected ? "var(  --font-weight-bold)" : "normal"};
 
   &:last-child {
     border-bottom: none;

--- a/src/components/common/SelectList/Group/GroupSelect.tsx
+++ b/src/components/common/SelectList/Group/GroupSelect.tsx
@@ -20,8 +20,8 @@ function GroupSelect({
       <Style.Option
         ref={innerRef}
         {...innerProps}
-        isFocused={isFocused}
-        isSelected={isSelected}
+        $isFocused={isFocused}
+        $isSelected={isSelected}
       >
         <ProfileImg size="small" src={data.profileImage} alt={data.label} />
         {data.label}

--- a/src/components/common/TimeInput/TimeInput.tsx
+++ b/src/components/common/TimeInput/TimeInput.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import * as Style from "./TimeInput.style";
 import { TimeInputProps } from "@/types/input.types";
 import { useToast } from "@/hooks/useToast";
@@ -34,10 +33,6 @@ function TimeInput({
     }
     onChange(startTime, newEndTime);
   };
-
-  useEffect(() => {
-    onChange(startTime, endTime);
-  }, [startTime, endTime, onChange]);
 
   return (
     <Style.Container>

--- a/src/components/common/Toggle/Toggle.tsx
+++ b/src/components/common/Toggle/Toggle.tsx
@@ -1,13 +1,14 @@
 import * as Styled from "./Toggle.style";
 
 interface IProps {
+  type: "time" | "alarm";
   isOn: boolean;
-  onClick: (isOn: boolean) => void;
+  onClick: (type: "time" | "alarm", isOn: boolean) => void;
 }
 
-function Toggle({ isOn, onClick }: IProps) {
+function Toggle({ type, isOn, onClick }: IProps) {
   return (
-    <Styled.ToggleWrapper onClick={() => onClick(!isOn)}>
+    <Styled.ToggleWrapper onClick={() => onClick(type, !isOn)}>
       <Styled.ToggleContainer $isOn={isOn}>
         <Styled.ToggleCircle $isOn={isOn} />
       </Styled.ToggleContainer>

--- a/src/components/common/Toggle/Toggle.tsx
+++ b/src/components/common/Toggle/Toggle.tsx
@@ -2,12 +2,12 @@ import * as Styled from "./Toggle.style";
 
 interface IProps {
   isOn: boolean;
-  onClick: () => void;
+  onClick: (isOn: boolean) => void;
 }
 
 function Toggle({ isOn, onClick }: IProps) {
   return (
-    <Styled.ToggleWrapper onClick={onClick}>
+    <Styled.ToggleWrapper onClick={() => onClick(!isOn)}>
       <Styled.ToggleContainer $isOn={isOn}>
         <Styled.ToggleCircle $isOn={isOn} />
       </Styled.ToggleContainer>

--- a/src/components/form/TodoScheduleForm/TodoScheduleForm.tsx
+++ b/src/components/form/TodoScheduleForm/TodoScheduleForm.tsx
@@ -12,6 +12,7 @@ import GroupSelect from "@/components/common/SelectList/Group/GroupSelect";
 interface TodoScheduleFormProps {
   form: ReturnType<typeof useTodoScheduleForm>;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  withCategory?: boolean;
   withEndDate?: boolean;
   withEndTime?: boolean;
   withGroup?: boolean;
@@ -22,6 +23,7 @@ interface TodoScheduleFormProps {
 function TodoScheduleForm({
   form,
   onSubmit,
+  withCategory = false,
   withEndDate = false,
   withEndTime = false,
   withGroup = false,
@@ -46,11 +48,13 @@ function TodoScheduleForm({
             onMemberChange={form.handleMemberUpdate}
           />
         )}
-        <CategorySelect
-          category={form.category}
-          options={form.list.categories}
-          onCategoryChange={form.handleCategoryUpdate}
-        />
+        {withCategory && (
+          <CategorySelect
+            category={form.category}
+            options={form.list.categories}
+            onCategoryChange={form.handleCategoryUpdate}
+          />
+        )}
         <Styled.ToggleContainer>
           <TextSetting text="시간 옵션" />
           <Toggle

--- a/src/components/form/TodoScheduleForm/TodoScheduleForm.tsx
+++ b/src/components/form/TodoScheduleForm/TodoScheduleForm.tsx
@@ -7,24 +7,27 @@ import Toggle from "@/components/common/Toggle/Toggle";
 import TextSetting from "@/components/common/TextSetting/TextSetting";
 import Button from "@/components/common/Button/Button";
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
+import GroupSelect from "@/components/common/SelectList/Group/GroupSelect";
 
-interface ScheduleFormProps {
+interface TodoScheduleFormProps {
   form: ReturnType<typeof useTodoScheduleForm>;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   withEndDate?: boolean;
   withEndTime?: boolean;
+  withGroup?: boolean;
   withAlarm?: boolean;
   submitButtonText: string;
 }
 
-function ScheduleForm({
+function TodoScheduleForm({
   form,
   onSubmit,
   withEndDate = false,
   withEndTime = false,
+  withGroup = false,
   withAlarm = false,
   submitButtonText,
-}: ScheduleFormProps) {
+}: TodoScheduleFormProps) {
   return (
     <Styled.Container>
       <Styled.Form onSubmit={onSubmit}>
@@ -36,6 +39,13 @@ function ScheduleForm({
           value={form.content}
           onChange={form.handleContentChange}
         />
+        {withGroup && (
+          <GroupSelect
+            groupMembers={form.memberList}
+            selectedMembers={form.member}
+            onMemberChange={form.handleMemberChange}
+          />
+        )}
         <CategorySelect
           category={form.category}
           options={form.categoryList}
@@ -73,4 +83,4 @@ function ScheduleForm({
   );
 }
 
-export default ScheduleForm;
+export default TodoScheduleForm;

--- a/src/components/form/TodoScheduleForm/TodoScheduleForm.tsx
+++ b/src/components/form/TodoScheduleForm/TodoScheduleForm.tsx
@@ -37,35 +37,39 @@ function TodoScheduleForm({
           placeholder="내용"
           required={false}
           value={form.content}
-          onChange={form.handleContentChange}
+          onChange={form.handleContentUpdate}
         />
         {withGroup && (
           <GroupSelect
-            groupMembers={form.list.member}
+            groupMembers={form.list.members}
             selectedMembers={form.member}
-            onMemberChange={form.handleMemberChange}
+            onMemberChange={form.handleMemberUpdate}
           />
         )}
         <CategorySelect
           category={form.category}
-          options={form.list.category}
-          onCategoryChange={form.handleCategoryChange}
+          options={form.list.categories}
+          onCategoryChange={form.handleCategoryUpdate}
         />
         <Styled.ToggleContainer>
           <TextSetting text="시간 옵션" />
-          <Toggle isOn={form.toggle.isTimeOn} onClick={form.handleTimeToggle} />
+          <Toggle
+            type="time"
+            isOn={form.toggle.isTimeOn}
+            onClick={form.handleToggleUpdate}
+          />
         </Styled.ToggleContainer>
         <DateInput
           startDate={form.date.start}
           endDate={withEndDate ? form.date.end : undefined}
-          onChange={form.handleDateChange}
+          onChange={form.handleDateUpdate}
           withEndDate={withEndDate}
         />
         {form.toggle.isTimeOn && (
           <TimeInput
             startTime={form.time.start}
             endTime={withEndTime ? form.time.end : undefined}
-            onChange={form.handleTimeChange}
+            onChange={form.handleTimeUpdate}
             withEndTime={withEndTime}
           />
         )}
@@ -73,8 +77,9 @@ function TodoScheduleForm({
           <Styled.ToggleContainer>
             <TextSetting text="알림 추가" />
             <Toggle
+              type="alarm"
               isOn={form.toggle.isAlarmOn}
-              onClick={form.handleAlarmToggle}
+              onClick={form.handleToggleUpdate}
             />
           </Styled.ToggleContainer>
         )}

--- a/src/components/form/TodoScheduleForm/TodoScheduleForm.tsx
+++ b/src/components/form/TodoScheduleForm/TodoScheduleForm.tsx
@@ -41,30 +41,30 @@ function TodoScheduleForm({
         />
         {withGroup && (
           <GroupSelect
-            groupMembers={form.memberList}
+            groupMembers={form.list.member}
             selectedMembers={form.member}
             onMemberChange={form.handleMemberChange}
           />
         )}
         <CategorySelect
           category={form.category}
-          options={form.categoryList}
+          options={form.list.category}
           onCategoryChange={form.handleCategoryChange}
         />
         <Styled.ToggleContainer>
           <TextSetting text="시간 옵션" />
-          <Toggle isOn={form.isTimeOn} onClick={form.handleTimeToggle} />
+          <Toggle isOn={form.toggle.isTimeOn} onClick={form.handleTimeToggle} />
         </Styled.ToggleContainer>
         <DateInput
-          startDate={form.startDate}
-          endDate={withEndDate ? form.endDate : undefined}
+          startDate={form.date.start}
+          endDate={withEndDate ? form.date.end : undefined}
           onChange={form.handleDateChange}
           withEndDate={withEndDate}
         />
-        {form.isTimeOn && (
+        {form.toggle.isTimeOn && (
           <TimeInput
-            startTime={form.startTime}
-            endTime={withEndTime ? form.endTime : undefined}
+            startTime={form.time.start}
+            endTime={withEndTime ? form.time.end : undefined}
             onChange={form.handleTimeChange}
             withEndTime={withEndTime}
           />
@@ -72,7 +72,10 @@ function TodoScheduleForm({
         {withAlarm && (
           <Styled.ToggleContainer>
             <TextSetting text="알림 추가" />
-            <Toggle isOn={form.isAlarmOn} onClick={form.handleAlarmToggle} />
+            <Toggle
+              isOn={form.toggle.isAlarmOn}
+              onClick={form.handleAlarmToggle}
+            />
           </Styled.ToggleContainer>
         )}
         <Button buttonType="primaryLarge" isHoverEffect={true} type="submit">

--- a/src/components/form/TodoScheduleForm/utils.ts
+++ b/src/components/form/TodoScheduleForm/utils.ts
@@ -17,21 +17,23 @@ export function setTodoScheduleForm(
   form: ReturnType<typeof useTodoScheduleForm>,
   data: TodoScheduleFormData
 ) {
-  if (data.content) form.handleContentChange(data.content);
-  if (data.category) form.handleCategoryChange(data.category);
-  if (data.member) form.handleMemberChange(data.member);
+  if (data.content) form.handleContentUpdate(data.content);
+  if (data.category) form.handleCategoryUpdate(data.category);
+  if (data.member) form.handleMemberUpdate(data.member);
   if (data.startDate || data.endDate) {
-    form.handleDateChange(
+    form.handleDateUpdate(
       data.startDate || form.date.start,
       data.endDate || form.date.end
     );
   }
   if (data.startTime || data.endTime) {
-    form.handleTimeChange(
+    form.handleTimeUpdate(
       data.startTime || form.time.start,
       data.endTime || form.time.end
     );
   }
-  if (data.isTimeOn !== undefined) form.handleTimeToggle(data.isTimeOn);
-  if (data.isAlarmOn !== undefined) form.handleAlarmToggle(data.isAlarmOn);
+  if (data.isTimeOn !== undefined)
+    form.handleToggleUpdate("time", data.isTimeOn);
+  if (data.isAlarmOn !== undefined)
+    form.handleToggleUpdate("alarm", data.isAlarmOn);
 }

--- a/src/components/form/TodoScheduleForm/utils.ts
+++ b/src/components/form/TodoScheduleForm/utils.ts
@@ -1,0 +1,37 @@
+import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
+import { GroupMember, OptionType } from "@/types/select.types";
+
+export interface TodoScheduleFormData {
+  content?: string;
+  category?: OptionType | null;
+  member?: GroupMember[];
+  startDate?: Date;
+  endDate?: Date;
+  startTime?: string;
+  endTime?: string;
+  isTimeOn?: boolean;
+  isAlarmOn?: boolean;
+}
+
+export function setTodoScheduleForm(
+  form: ReturnType<typeof useTodoScheduleForm>,
+  data: TodoScheduleFormData
+) {
+  if (data.content) form.handleContentChange(data.content);
+  if (data.category) form.handleCategoryChange(data.category);
+  if (data.member) form.handleMemberChange(data.member);
+  if (data.startDate || data.endDate) {
+    form.handleDateChange(
+      data.startDate || form.date.start,
+      data.endDate || form.date.end
+    );
+  }
+  if (data.startTime || data.endTime) {
+    form.handleTimeChange(
+      data.startTime || form.time.start,
+      data.endTime || form.time.end
+    );
+  }
+  if (data.isTimeOn !== undefined) form.handleTimeToggle(data.isTimeOn);
+  if (data.isAlarmOn !== undefined) form.handleAlarmToggle(data.isAlarmOn);
+}

--- a/src/hooks/useTodoScheduleForm.ts
+++ b/src/hooks/useTodoScheduleForm.ts
@@ -1,25 +1,36 @@
 import { useState } from "react";
-import { OptionType } from "@/types/select.types";
+import { GroupMember, OptionType } from "@/types/select.types";
 import { useToast } from "@/hooks/useToast";
 
 interface useTodoScheduleFormProps {
-  withEndDate?: boolean;
-  withEndTime?: boolean;
+  withEndDate?: boolean; // 종료일 입력 여부
+  withEndTime?: boolean; // 종료시간 입력 여부
+  withGroup?: boolean; // 그룹원 선택 여부
 }
 
 export const useTodoScheduleForm = ({
   withEndDate = false,
   withEndTime = false,
+  withGroup = false,
 }: useTodoScheduleFormProps = {}) => {
+  // 내용
   const [content, setContent] = useState<string>("");
+  // 카테고리
   const [categoryList, setCategoryList] = useState<OptionType[]>([]);
   const [category, setCategory] = useState<OptionType | null>(null);
+  // 멤버
+  const [memberList, setMemberList] = useState<GroupMember[]>([]);
+  const [member, setMember] = useState<GroupMember[]>([]);
+  // 날짜
   const [startDate, setStartDate] = useState<Date>(new Date());
   const [endDate, setEndDate] = useState<Date>(new Date());
+  // 시간
   const [startTime, setStartTime] = useState<string>("09:00");
   const [endTime, setEndTime] = useState<string>("10:00");
+  // 토글
   const [isTimeOn, setIsTimeOn] = useState<boolean>(false);
   const [isAlarmOn, setIsAlarmOn] = useState<boolean>(false);
+  // 토스트
   const { showToast } = useToast();
 
   const handleContentChange = (value: string) => {
@@ -28,6 +39,10 @@ export const useTodoScheduleForm = ({
 
   const handleCategoryChange = (value: OptionType | null) => {
     setCategory(value);
+  };
+
+  const handleMemberChange = (value: GroupMember[]) => {
+    setMember(value);
   };
 
   const handleDateChange = (newStartDate: Date, newEndDate?: Date) => {
@@ -58,6 +73,10 @@ export const useTodoScheduleForm = ({
       showToast("카테고리를 입력해주세요.", "error");
       ok = false;
     }
+    if (withGroup && member.length === 0) {
+      showToast("멤버를 선택해주세요.", "error");
+      ok = false;
+    }
     return ok;
   };
 
@@ -66,6 +85,10 @@ export const useTodoScheduleForm = ({
     setContent,
     categoryList,
     setCategoryList,
+    memberList,
+    setMemberList,
+    member,
+    setMember,
     category,
     setCategory,
     startDate,
@@ -82,6 +105,7 @@ export const useTodoScheduleForm = ({
     setIsAlarmOn,
     handleContentChange,
     handleCategoryChange,
+    handleMemberChange,
     handleDateChange,
     handleTimeChange,
     handleTimeToggle,

--- a/src/hooks/useTodoScheduleForm.ts
+++ b/src/hooks/useTodoScheduleForm.ts
@@ -19,8 +19,8 @@ interface TodoScheduleFormState {
     isAlarmOn: boolean; // 알람 설정 여부
   };
   list: {
-    category: OptionType[]; // 카테고리 목록
-    member: GroupMember[]; // 멤버 목록
+    categories: OptionType[]; // 카테고리 목록
+    members: GroupMember[]; // 멤버 목록
   };
 }
 
@@ -53,32 +53,32 @@ export function useTodoScheduleForm({
       isAlarmOn: false,
     },
     list: {
-      category: [],
-      member: [],
+      categories: [],
+      members: [],
     },
   });
 
   const { showToast } = useToast();
 
   // 폼 전체 업데이트 함수
-  const updateForm = (updates: Partial<TodoScheduleFormState>) => {
+  const handleFormUpdate = (updates: Partial<TodoScheduleFormState>) => {
     setForm((prev) => ({ ...prev, ...updates }));
   };
 
-  const handleContentChange = (value: string) => {
-    updateForm({ content: value });
+  const handleContentUpdate = (value: string) => {
+    handleFormUpdate({ content: value });
   };
 
-  const handleCategoryChange = (value: OptionType | null) => {
-    updateForm({ category: value });
+  const handleCategoryUpdate = (value: OptionType | null) => {
+    handleFormUpdate({ category: value });
   };
 
-  const handleMemberChange = (value: GroupMember[]) => {
-    updateForm({ member: value });
+  const handleMemberUpdate = (value: GroupMember[]) => {
+    handleFormUpdate({ member: value });
   };
 
-  const handleDateChange = (newStartDate: Date, newEndDate?: Date) => {
-    updateForm({
+  const handleDateUpdate = (newStartDate: Date, newEndDate?: Date) => {
+    handleFormUpdate({
       date: {
         start: newStartDate,
         end: withEndDate && newEndDate ? newEndDate : newStartDate,
@@ -86,8 +86,8 @@ export function useTodoScheduleForm({
     });
   };
 
-  const handleTimeChange = (newStartTime: string, newEndTime?: string) => {
-    updateForm({
+  const handleTimeUpdate = (newStartTime: string, newEndTime?: string) => {
+    handleFormUpdate({
       time: {
         start: newStartTime,
         end: withEndTime && newEndTime ? newEndTime : newStartTime,
@@ -95,44 +95,30 @@ export function useTodoScheduleForm({
     });
   };
 
-  const handleTimeToggle = (isOn: boolean) => {
-    updateForm({
+  const handleToggleUpdate = (type: "time" | "alarm", isOn: boolean) => {
+    handleFormUpdate({
       toggle: {
         ...form.toggle,
-        isTimeOn: isOn,
+        [type === "time" ? "isTimeOn" : "isAlarmOn"]: isOn,
       },
     });
   };
 
-  const handleAlarmToggle = (isOn: boolean) => {
-    updateForm({
-      toggle: {
-        ...form.toggle,
-        isAlarmOn: isOn,
-      },
-    });
-  };
-
-  const handleCategoryListChange = (categories: OptionType[]) => {
-    updateForm({
+  const handleListUpdate = (updates: {
+    categories?: OptionType[];
+    members?: GroupMember[];
+  }) => {
+    handleFormUpdate({
       list: {
         ...form.list,
-        category: categories,
-      },
-    });
-  };
-
-  const handleMemberListChange = (members: GroupMember[]) => {
-    updateForm({
-      list: {
-        ...form.list,
-        member: members,
+        ...(updates.categories && { categories: updates.categories }),
+        ...(updates.members && { members: updates.members }),
       },
     });
   };
 
   // 폼 유효성 검사 함수
-  const validateContentAndCategory = () => {
+  const handleFormValidation = () => {
     const validationRules = [
       { condition: !form.content, message: "내용을 입력해주세요." },
       { condition: !form.category, message: "카테고리를 입력해주세요." },
@@ -154,16 +140,14 @@ export function useTodoScheduleForm({
   // 폼 상태와 핸들러 함수들을 반환
   return {
     ...form,
-    updateForm,
-    handleContentChange,
-    handleCategoryChange,
-    handleMemberChange,
-    handleDateChange,
-    handleTimeChange,
-    handleTimeToggle,
-    handleAlarmToggle,
-    handleCategoryListChange,
-    handleMemberListChange,
-    validateContentAndCategory,
+    handleFormUpdate,
+    handleContentUpdate,
+    handleCategoryUpdate,
+    handleMemberUpdate,
+    handleDateUpdate,
+    handleTimeUpdate,
+    handleToggleUpdate,
+    handleListUpdate,
+    handleFormValidation,
   };
 }

--- a/src/pages/group/schedule/edit/GroupScheduleEditPage.tsx
+++ b/src/pages/group/schedule/edit/GroupScheduleEditPage.tsx
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
 import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+import {
+  setTodoScheduleForm,
+  TodoScheduleFormData,
+} from "@/components/form/TodoScheduleForm/utils";
 
 function GroupScheduleEditPage() {
   const form = useTodoScheduleForm({
@@ -12,21 +16,12 @@ function GroupScheduleEditPage() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!form.validateContentAndCategory()) return;
-    console.log(
-      form.content,
-      form.category,
-      form.member,
-      form.startDate,
-      form.endDate,
-      form.startTime,
-      form.endTime
-    );
     // Todo 생성 api
   };
 
   useEffect(() => {
     // 카테고리 목록 가져오는 api
-    form.setCategoryList([
+    form.handleCategoryListChange([
       { name: "카테고리1", color: "blue" },
       { name: "카테고리2", color: "red" },
       { name: "카테고리3", color: "black" },
@@ -35,7 +30,7 @@ function GroupScheduleEditPage() {
 
   useEffect(() => {
     // 멤버 목록 가져오는 api
-    form.setMemberList([
+    form.handleMemberListChange([
       {
         value: "1",
         label: "이름1",
@@ -58,17 +53,22 @@ function GroupScheduleEditPage() {
   }, []);
 
   useEffect(() => {
-    // 투두 가져오는 api
-    form.setContent("투두 내용");
-    form.setCategory({ name: "카테고리1", color: "blue" });
-    form.setMember([
-      { value: "1", label: "이름1", profileImage: "" },
-      { value: "2", label: "이름2", profileImage: "" },
-    ]);
-    form.setStartDate(new Date());
-    form.setEndDate(new Date());
-    form.setStartTime("17:00");
-    form.setEndTime("18:00");
+    // 임시 데이터
+    const data: TodoScheduleFormData = {
+      content: "투두 내용",
+      category: { name: "카테고리1", color: "blue" },
+      member: [
+        { value: "1", label: "이름1", profileImage: "" },
+        { value: "2", label: "이름2", profileImage: "" },
+      ],
+      startDate: new Date(),
+      endDate: new Date(new Date().setDate(new Date().getDate() + 1)),
+      startTime: "17:00",
+      endTime: "18:00",
+      isTimeOn: true,
+      isAlarmOn: true,
+    };
+    setTodoScheduleForm(form, data);
   }, []);
 
   return (
@@ -77,6 +77,7 @@ function GroupScheduleEditPage() {
       withEndDate={true}
       withEndTime={true}
       withGroup={true}
+      withAlarm={true}
       onSubmit={handleSubmit}
       submitButtonText="생성"
     />

--- a/src/pages/group/schedule/edit/GroupScheduleEditPage.tsx
+++ b/src/pages/group/schedule/edit/GroupScheduleEditPage.tsx
@@ -1,5 +1,86 @@
+import { useEffect } from "react";
+import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
+import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+
 function GroupScheduleEditPage() {
-  return <div>GroupScheduleEditPage</div>;
+  const form = useTodoScheduleForm({
+    withEndDate: true,
+    withEndTime: true,
+    withGroup: true,
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!form.validateContentAndCategory()) return;
+    console.log(
+      form.content,
+      form.category,
+      form.member,
+      form.startDate,
+      form.endDate,
+      form.startTime,
+      form.endTime
+    );
+    // Todo 생성 api
+  };
+
+  useEffect(() => {
+    // 카테고리 목록 가져오는 api
+    form.setCategoryList([
+      { name: "카테고리1", color: "blue" },
+      { name: "카테고리2", color: "red" },
+      { name: "카테고리3", color: "black" },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    // 멤버 목록 가져오는 api
+    form.setMemberList([
+      {
+        value: "1",
+        label: "이름1",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+      {
+        value: "2",
+        label: "이름2",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+      {
+        value: "3",
+        label: "이름3",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    // 투두 가져오는 api
+    form.setContent("투두 내용");
+    form.setCategory({ name: "카테고리1", color: "blue" });
+    form.setMember([
+      { value: "1", label: "이름1", profileImage: "" },
+      { value: "2", label: "이름2", profileImage: "" },
+    ]);
+    form.setStartDate(new Date());
+    form.setEndDate(new Date());
+    form.setStartTime("17:00");
+    form.setEndTime("18:00");
+  }, []);
+
+  return (
+    <TodoScheduleForm
+      form={form}
+      withEndDate={true}
+      withEndTime={true}
+      withGroup={true}
+      onSubmit={handleSubmit}
+      submitButtonText="생성"
+    />
+  );
 }
 
 export default GroupScheduleEditPage;

--- a/src/pages/group/schedule/edit/GroupScheduleEditPage.tsx
+++ b/src/pages/group/schedule/edit/GroupScheduleEditPage.tsx
@@ -15,41 +15,39 @@ function GroupScheduleEditPage() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!form.validateContentAndCategory()) return;
+    if (!form.handleFormValidation()) return;
     // Todo 생성 api
   };
 
   useEffect(() => {
-    // 카테고리 목록 가져오는 api
-    form.handleCategoryListChange([
-      { name: "카테고리1", color: "blue" },
-      { name: "카테고리2", color: "red" },
-      { name: "카테고리3", color: "black" },
-    ]);
-  }, []);
-
-  useEffect(() => {
-    // 멤버 목록 가져오는 api
-    form.handleMemberListChange([
-      {
-        value: "1",
-        label: "이름1",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-      {
-        value: "2",
-        label: "이름2",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-      {
-        value: "3",
-        label: "이름3",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-    ]);
+    // 카테고리와 멤버 목록을 동시에 업데이트
+    form.handleListUpdate({
+      categories: [
+        { name: "카테고리1", color: "blue" },
+        { name: "카테고리2", color: "red" },
+        { name: "카테고리3", color: "black" },
+      ],
+      members: [
+        {
+          value: "1",
+          label: "이름1",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+        {
+          value: "2",
+          label: "이름2",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+        {
+          value: "3",
+          label: "이름3",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+      ],
+    });
   }, []);
 
   useEffect(() => {

--- a/src/pages/group/schedule/new/GroupScheduleNewPage.tsx
+++ b/src/pages/group/schedule/new/GroupScheduleNewPage.tsx
@@ -11,41 +11,39 @@ function GroupScheduleNewPage() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!form.validateContentAndCategory()) return;
+    if (!form.handleFormValidation()) return;
     // Todo 생성 api
   };
 
   useEffect(() => {
-    // 카테고리 목록 가져오는 api
-    form.handleCategoryListChange([
-      { name: "카테고리1", color: "blue" },
-      { name: "카테고리2", color: "red" },
-      { name: "카테고리3", color: "black" },
-    ]);
-  }, []);
-
-  useEffect(() => {
-    // 멤버 목록 가져오는 api
-    form.handleMemberListChange([
-      {
-        value: "1",
-        label: "이름1",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-      {
-        value: "2",
-        label: "이름2",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-      {
-        value: "3",
-        label: "이름3",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-    ]);
+    // 카테고리와 멤버 목록을 동시에 업데이트
+    form.handleListUpdate({
+      categories: [
+        { name: "카테고리1", color: "blue" },
+        { name: "카테고리2", color: "red" },
+        { name: "카테고리3", color: "black" },
+      ],
+      members: [
+        {
+          value: "1",
+          label: "이름1",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+        {
+          value: "2",
+          label: "이름2",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+        {
+          value: "3",
+          label: "이름3",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+      ],
+    });
   }, []);
 
   return (

--- a/src/pages/group/schedule/new/GroupScheduleNewPage.tsx
+++ b/src/pages/group/schedule/new/GroupScheduleNewPage.tsx
@@ -1,5 +1,72 @@
+import { useEffect } from "react";
+import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
+import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+
 function GroupScheduleNewPage() {
-  return <div>GroupScheduleNewPage</div>;
+  const form = useTodoScheduleForm({
+    withEndDate: true,
+    withEndTime: true,
+    withGroup: true,
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!form.validateContentAndCategory()) return;
+    console.log(
+      form.content,
+      form.category,
+      form.member,
+      form.startDate,
+      form.endDate,
+      form.startTime,
+      form.endTime
+    );
+    // Todo 생성 api
+  };
+
+  useEffect(() => {
+    // 카테고리 목록 가져오는 api
+    form.setCategoryList([
+      { name: "카테고리1", color: "blue" },
+      { name: "카테고리2", color: "red" },
+      { name: "카테고리3", color: "black" },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    // 멤버 목록 가져오는 api
+    form.setMemberList([
+      {
+        value: "1",
+        label: "이름1",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+      {
+        value: "2",
+        label: "이름2",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+      {
+        value: "3",
+        label: "이름3",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+    ]);
+  }, []);
+
+  return (
+    <TodoScheduleForm
+      form={form}
+      withEndDate={true}
+      withEndTime={true}
+      withGroup={true}
+      onSubmit={handleSubmit}
+      submitButtonText="생성"
+    />
+  );
 }
 
 export default GroupScheduleNewPage;

--- a/src/pages/group/schedule/new/GroupScheduleNewPage.tsx
+++ b/src/pages/group/schedule/new/GroupScheduleNewPage.tsx
@@ -12,21 +12,12 @@ function GroupScheduleNewPage() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!form.validateContentAndCategory()) return;
-    console.log(
-      form.content,
-      form.category,
-      form.member,
-      form.startDate,
-      form.endDate,
-      form.startTime,
-      form.endTime
-    );
     // Todo 생성 api
   };
 
   useEffect(() => {
     // 카테고리 목록 가져오는 api
-    form.setCategoryList([
+    form.handleCategoryListChange([
       { name: "카테고리1", color: "blue" },
       { name: "카테고리2", color: "red" },
       { name: "카테고리3", color: "black" },
@@ -35,7 +26,7 @@ function GroupScheduleNewPage() {
 
   useEffect(() => {
     // 멤버 목록 가져오는 api
-    form.setMemberList([
+    form.handleMemberListChange([
       {
         value: "1",
         label: "이름1",
@@ -63,6 +54,7 @@ function GroupScheduleNewPage() {
       withEndDate={true}
       withEndTime={true}
       withGroup={true}
+      withAlarm={true}
       onSubmit={handleSubmit}
       submitButtonText="생성"
     />

--- a/src/pages/group/todo/edit/GroupTodoEditPage.tsx
+++ b/src/pages/group/todo/edit/GroupTodoEditPage.tsx
@@ -1,5 +1,76 @@
+import { useEffect } from "react";
+import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
+import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+
 function GroupTodoEditPage() {
-  return <div>GroupTodoEditPage</div>;
+  const form = useTodoScheduleForm({ withGroup: true });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!form.validateContentAndCategory()) return;
+    console.log(
+      form.content,
+      form.category,
+      form.member,
+      form.startDate,
+      form.startTime
+    );
+    // Todo 생성 api
+  };
+
+  useEffect(() => {
+    // 카테고리 목록 가져오는 api
+    form.setCategoryList([
+      { name: "카테고리1", color: "blue" },
+      { name: "카테고리2", color: "red" },
+      { name: "카테고리3", color: "black" },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    // 멤버 목록 가져오는 api
+    form.setMemberList([
+      {
+        value: "1",
+        label: "이름1",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+      {
+        value: "2",
+        label: "이름2",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+      {
+        value: "3",
+        label: "이름3",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    // 투두 가져오는 api
+    form.setContent("투두 내용");
+    form.setCategory({ name: "카테고리1", color: "blue" });
+    form.setMember([
+      { value: "1", label: "이름1", profileImage: "" },
+      { value: "2", label: "이름2", profileImage: "" },
+    ]);
+    form.setStartDate(new Date());
+    form.setStartTime("17:00");
+  }, []);
+
+  return (
+    <TodoScheduleForm
+      form={form}
+      withGroup={true}
+      onSubmit={handleSubmit}
+      submitButtonText="생성"
+    />
+  );
 }
 
 export default GroupTodoEditPage;

--- a/src/pages/group/todo/edit/GroupTodoEditPage.tsx
+++ b/src/pages/group/todo/edit/GroupTodoEditPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
 import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+import { TodoScheduleFormData } from "@/components/form/TodoScheduleForm/utils";
+import { setTodoScheduleForm } from "@/components/form/TodoScheduleForm/utils";
 
 function GroupTodoEditPage() {
   const form = useTodoScheduleForm({ withGroup: true });
@@ -8,19 +10,12 @@ function GroupTodoEditPage() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!form.validateContentAndCategory()) return;
-    console.log(
-      form.content,
-      form.category,
-      form.member,
-      form.startDate,
-      form.startTime
-    );
     // Todo 생성 api
   };
 
   useEffect(() => {
     // 카테고리 목록 가져오는 api
-    form.setCategoryList([
+    form.handleCategoryListChange([
       { name: "카테고리1", color: "blue" },
       { name: "카테고리2", color: "red" },
       { name: "카테고리3", color: "black" },
@@ -29,7 +24,7 @@ function GroupTodoEditPage() {
 
   useEffect(() => {
     // 멤버 목록 가져오는 api
-    form.setMemberList([
+    form.handleMemberListChange([
       {
         value: "1",
         label: "이름1",
@@ -52,15 +47,19 @@ function GroupTodoEditPage() {
   }, []);
 
   useEffect(() => {
-    // 투두 가져오는 api
-    form.setContent("투두 내용");
-    form.setCategory({ name: "카테고리1", color: "blue" });
-    form.setMember([
-      { value: "1", label: "이름1", profileImage: "" },
-      { value: "2", label: "이름2", profileImage: "" },
-    ]);
-    form.setStartDate(new Date());
-    form.setStartTime("17:00");
+    // 임시 데이터
+    const data: TodoScheduleFormData = {
+      content: "투두 내용",
+      category: { name: "카테고리1", color: "blue" },
+      member: [
+        { value: "1", label: "이름1", profileImage: "" },
+        { value: "2", label: "이름2", profileImage: "" },
+      ],
+      startDate: new Date(),
+      startTime: "17:00",
+      isTimeOn: true,
+    };
+    setTodoScheduleForm(form, data);
   }, []);
 
   return (

--- a/src/pages/group/todo/edit/GroupTodoEditPage.tsx
+++ b/src/pages/group/todo/edit/GroupTodoEditPage.tsx
@@ -9,41 +9,39 @@ function GroupTodoEditPage() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!form.validateContentAndCategory()) return;
+    if (!form.handleFormValidation()) return;
     // Todo 생성 api
   };
 
   useEffect(() => {
-    // 카테고리 목록 가져오는 api
-    form.handleCategoryListChange([
-      { name: "카테고리1", color: "blue" },
-      { name: "카테고리2", color: "red" },
-      { name: "카테고리3", color: "black" },
-    ]);
-  }, []);
-
-  useEffect(() => {
-    // 멤버 목록 가져오는 api
-    form.handleMemberListChange([
-      {
-        value: "1",
-        label: "이름1",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-      {
-        value: "2",
-        label: "이름2",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-      {
-        value: "3",
-        label: "이름3",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-    ]);
+    // 카테고리와 멤버 목록을 동시에 업데이트
+    form.handleListUpdate({
+      categories: [
+        { name: "카테고리1", color: "blue" },
+        { name: "카테고리2", color: "red" },
+        { name: "카테고리3", color: "black" },
+      ],
+      members: [
+        {
+          value: "1",
+          label: "이름1",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+        {
+          value: "2",
+          label: "이름2",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+        {
+          value: "3",
+          label: "이름3",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+      ],
+    });
   }, []);
 
   useEffect(() => {

--- a/src/pages/group/todo/new/GroupTodoNewPage.tsx
+++ b/src/pages/group/todo/new/GroupTodoNewPage.tsx
@@ -1,5 +1,64 @@
+import { useEffect } from "react";
+import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
+import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+
 function GroupTodoNewPage() {
-  return <div>GroupTodoNewPage</div>;
+  const form = useTodoScheduleForm({ withGroup: true });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!form.validateContentAndCategory()) return;
+    console.log(
+      form.content,
+      form.category,
+      form.member,
+      form.startDate,
+      form.startTime
+    );
+    // Todo 생성 api
+  };
+
+  useEffect(() => {
+    // 카테고리 목록 가져오는 api
+    form.setCategoryList([
+      { name: "카테고리1", color: "blue" },
+      { name: "카테고리2", color: "red" },
+      { name: "카테고리3", color: "black" },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    // 멤버 목록 가져오는 api
+    form.setMemberList([
+      {
+        value: "1",
+        label: "이름1",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+      {
+        value: "2",
+        label: "이름2",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+      {
+        value: "3",
+        label: "이름3",
+        profileImage:
+          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+      },
+    ]);
+  }, []);
+
+  return (
+    <TodoScheduleForm
+      form={form}
+      withGroup={true}
+      onSubmit={handleSubmit}
+      submitButtonText="생성"
+    />
+  );
 }
 
 export default GroupTodoNewPage;

--- a/src/pages/group/todo/new/GroupTodoNewPage.tsx
+++ b/src/pages/group/todo/new/GroupTodoNewPage.tsx
@@ -7,41 +7,39 @@ function GroupTodoNewPage() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!form.validateContentAndCategory()) return;
+    if (!form.handleFormValidation()) return;
     // Todo 생성 api
   };
 
   useEffect(() => {
-    // 카테고리 목록 가져오는 api
-    form.handleCategoryListChange([
-      { name: "카테고리1", color: "blue" },
-      { name: "카테고리2", color: "red" },
-      { name: "카테고리3", color: "black" },
-    ]);
-  }, []);
-
-  useEffect(() => {
-    // 멤버 목록 가져오는 api
-    form.handleMemberListChange([
-      {
-        value: "1",
-        label: "이름1",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-      {
-        value: "2",
-        label: "이름2",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-      {
-        value: "3",
-        label: "이름3",
-        profileImage:
-          "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
-      },
-    ]);
+    // 카테고리와 멤버 목록을 동시에 업데이트
+    form.handleListUpdate({
+      categories: [
+        { name: "카테고리1", color: "blue" },
+        { name: "카테고리2", color: "red" },
+        { name: "카테고리3", color: "black" },
+      ],
+      members: [
+        {
+          value: "1",
+          label: "이름1",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+        {
+          value: "2",
+          label: "이름2",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+        {
+          value: "3",
+          label: "이름3",
+          profileImage:
+            "https://img.freepik.com/premium-photo/sunset-sea-illustration-beautiful-landscape_900706-748.jpg",
+        },
+      ],
+    });
   }, []);
 
   return (

--- a/src/pages/group/todo/new/GroupTodoNewPage.tsx
+++ b/src/pages/group/todo/new/GroupTodoNewPage.tsx
@@ -8,19 +8,12 @@ function GroupTodoNewPage() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!form.validateContentAndCategory()) return;
-    console.log(
-      form.content,
-      form.category,
-      form.member,
-      form.startDate,
-      form.startTime
-    );
     // Todo 생성 api
   };
 
   useEffect(() => {
     // 카테고리 목록 가져오는 api
-    form.setCategoryList([
+    form.handleCategoryListChange([
       { name: "카테고리1", color: "blue" },
       { name: "카테고리2", color: "red" },
       { name: "카테고리3", color: "black" },
@@ -29,7 +22,7 @@ function GroupTodoNewPage() {
 
   useEffect(() => {
     // 멤버 목록 가져오는 api
-    form.setMemberList([
+    form.handleMemberListChange([
       {
         value: "1",
         label: "이름1",

--- a/src/pages/main/schedule/edit/MainScheduleEditPage.tsx
+++ b/src/pages/main/schedule/edit/MainScheduleEditPage.tsx
@@ -12,17 +12,19 @@ function MainScheduleEditPage() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!form.validateContentAndCategory()) return;
+    if (!form.handleFormValidation()) return;
     // 스케줄 생성 api
   };
 
   useEffect(() => {
-    // 카테고리 목록 가져오는 api
-    form.handleCategoryListChange([
-      { name: "카테고리1", color: "blue" },
-      { name: "카테고리2", color: "red" },
-      { name: "카테고리3", color: "black" },
-    ]);
+    // 카테고리 목록을 업데이트
+    form.handleListUpdate({
+      categories: [
+        { name: "카테고리1", color: "blue" },
+        { name: "카테고리2", color: "red" },
+        { name: "카테고리3", color: "black" },
+      ],
+    });
   }, []);
 
   useEffect(() => {

--- a/src/pages/main/schedule/edit/MainScheduleEditPage.tsx
+++ b/src/pages/main/schedule/edit/MainScheduleEditPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
 import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+import { TodoScheduleFormData } from "@/components/form/TodoScheduleForm/utils";
+import { setTodoScheduleForm } from "@/components/form/TodoScheduleForm/utils";
 
 function MainScheduleEditPage() {
   const form = useTodoScheduleForm({
@@ -11,21 +13,12 @@ function MainScheduleEditPage() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!form.validateContentAndCategory()) return;
-    console.log(
-      form.content,
-      form.category,
-      form.startDate,
-      form.endDate,
-      form.startTime,
-      form.endTime,
-      form.isAlarmOn
-    );
     // 스케줄 생성 api
   };
 
   useEffect(() => {
     // 카테고리 목록 가져오는 api
-    form.setCategoryList([
+    form.handleCategoryListChange([
       { name: "카테고리1", color: "blue" },
       { name: "카테고리2", color: "red" },
       { name: "카테고리3", color: "black" },
@@ -33,15 +26,18 @@ function MainScheduleEditPage() {
   }, []);
 
   useEffect(() => {
-    // 일정 내용 가져오는 api
-    form.setContent("임의의 내용");
-    form.setCategory({ name: "카테고리1", color: "blue" });
-    form.setStartDate(new Date());
-    form.setEndDate(new Date(new Date().setDate(new Date().getDate() + 1)));
-    form.setStartTime("11:00");
-    form.setEndTime("14:00");
-    form.setIsTimeOn(true);
-    form.setIsAlarmOn(true);
+    // 임시 데이터
+    const data: TodoScheduleFormData = {
+      content: "투두 내용",
+      category: { name: "카테고리1", color: "blue" },
+      startDate: new Date(),
+      endDate: new Date(new Date().setDate(new Date().getDate() + 1)),
+      startTime: "17:00",
+      endTime: "18:00",
+      isTimeOn: true,
+      isAlarmOn: true,
+    };
+    setTodoScheduleForm(form, data);
   }, []);
 
   return (

--- a/src/pages/main/schedule/edit/MainScheduleEditPage.tsx
+++ b/src/pages/main/schedule/edit/MainScheduleEditPage.tsx
@@ -46,6 +46,7 @@ function MainScheduleEditPage() {
     <TodoScheduleForm
       form={form}
       onSubmit={handleSubmit}
+      withCategory={true}
       withEndDate={true}
       withEndTime={true}
       withAlarm={true}

--- a/src/pages/main/schedule/edit/MainScheduleEditPage.tsx
+++ b/src/pages/main/schedule/edit/MainScheduleEditPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
-import ScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
 
 function MainScheduleEditPage() {
   const form = useTodoScheduleForm({
@@ -45,7 +45,7 @@ function MainScheduleEditPage() {
   }, []);
 
   return (
-    <ScheduleForm
+    <TodoScheduleForm
       form={form}
       onSubmit={handleSubmit}
       withEndDate={true}

--- a/src/pages/main/schedule/new/MainScheduleNewPage.tsx
+++ b/src/pages/main/schedule/new/MainScheduleNewPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
-import ScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
 
 function MainScheduleNewPage() {
   const form = useTodoScheduleForm({
@@ -33,7 +33,7 @@ function MainScheduleNewPage() {
   }, []);
 
   return (
-    <ScheduleForm
+    <TodoScheduleForm
       form={form}
       onSubmit={handleSubmit}
       withEndDate={true}

--- a/src/pages/main/schedule/new/MainScheduleNewPage.tsx
+++ b/src/pages/main/schedule/new/MainScheduleNewPage.tsx
@@ -11,21 +11,12 @@ function MainScheduleNewPage() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!form.validateContentAndCategory()) return;
-    console.log(
-      form.content,
-      form.category,
-      form.startDate,
-      form.endDate,
-      form.startTime,
-      form.endTime,
-      form.isAlarmOn
-    );
     // 스케줄 생성 api
   };
 
   useEffect(() => {
     // 카테고리 목록 가져오는 api
-    form.setCategoryList([
+    form.handleCategoryListChange([
       { name: "카테고리1", color: "blue" },
       { name: "카테고리2", color: "red" },
       { name: "카테고리3", color: "black" },

--- a/src/pages/main/schedule/new/MainScheduleNewPage.tsx
+++ b/src/pages/main/schedule/new/MainScheduleNewPage.tsx
@@ -29,6 +29,7 @@ function MainScheduleNewPage() {
     <TodoScheduleForm
       form={form}
       onSubmit={handleSubmit}
+      withCategory={true}
       withEndDate={true}
       withEndTime={true}
       withAlarm={true}

--- a/src/pages/main/schedule/new/MainScheduleNewPage.tsx
+++ b/src/pages/main/schedule/new/MainScheduleNewPage.tsx
@@ -10,17 +10,19 @@ function MainScheduleNewPage() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!form.validateContentAndCategory()) return;
+    if (!form.handleFormValidation()) return;
     // 스케줄 생성 api
   };
 
   useEffect(() => {
-    // 카테고리 목록 가져오는 api
-    form.handleCategoryListChange([
-      { name: "카테고리1", color: "blue" },
-      { name: "카테고리2", color: "red" },
-      { name: "카테고리3", color: "black" },
-    ]);
+    // 카테고리 목록을 업데이트
+    form.handleListUpdate({
+      categories: [
+        { name: "카테고리1", color: "blue" },
+        { name: "카테고리2", color: "red" },
+        { name: "카테고리3", color: "black" },
+      ],
+    });
   }, []);
 
   return (

--- a/src/pages/main/todo/edit/MainTodoEditPage.tsx
+++ b/src/pages/main/todo/edit/MainTodoEditPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
-import ScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
 
 function MainTodoEditPage() {
   const form = useTodoScheduleForm();
@@ -31,7 +31,11 @@ function MainTodoEditPage() {
   }, []);
 
   return (
-    <ScheduleForm form={form} onSubmit={handleSubmit} submitButtonText="수정" />
+    <TodoScheduleForm
+      form={form}
+      onSubmit={handleSubmit}
+      submitButtonText="수정"
+    />
   );
 }
 

--- a/src/pages/main/todo/edit/MainTodoEditPage.tsx
+++ b/src/pages/main/todo/edit/MainTodoEditPage.tsx
@@ -9,17 +9,19 @@ function MainTodoEditPage() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!form.validateContentAndCategory()) return;
+    if (!form.handleFormValidation()) return;
     // Todo 수정 api
   };
 
   useEffect(() => {
-    // 카테고리 목록 가져오는 api
-    form.handleCategoryListChange([
-      { name: "카테고리1", color: "blue" },
-      { name: "카테고리2", color: "red" },
-      { name: "카테고리3", color: "black" },
-    ]);
+    // 카테고리 목록을 업데이트
+    form.handleListUpdate({
+      categories: [
+        { name: "카테고리1", color: "blue" },
+        { name: "카테고리2", color: "red" },
+        { name: "카테고리3", color: "black" },
+      ],
+    });
   }, []);
 
   useEffect(() => {

--- a/src/pages/main/todo/edit/MainTodoEditPage.tsx
+++ b/src/pages/main/todo/edit/MainTodoEditPage.tsx
@@ -40,6 +40,7 @@ function MainTodoEditPage() {
     <TodoScheduleForm
       form={form}
       onSubmit={handleSubmit}
+      withCategory={true}
       submitButtonText="수정"
     />
   );

--- a/src/pages/main/todo/edit/MainTodoEditPage.tsx
+++ b/src/pages/main/todo/edit/MainTodoEditPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
 import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+import { TodoScheduleFormData } from "@/components/form/TodoScheduleForm/utils";
+import { setTodoScheduleForm } from "@/components/form/TodoScheduleForm/utils";
 
 function MainTodoEditPage() {
   const form = useTodoScheduleForm();
@@ -8,13 +10,12 @@ function MainTodoEditPage() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!form.validateContentAndCategory()) return;
-    console.log(form.content, form.category, form.startDate, form.startTime);
     // Todo 수정 api
   };
 
   useEffect(() => {
     // 카테고리 목록 가져오는 api
-    form.setCategoryList([
+    form.handleCategoryListChange([
       { name: "카테고리1", color: "blue" },
       { name: "카테고리2", color: "red" },
       { name: "카테고리3", color: "black" },
@@ -22,12 +23,15 @@ function MainTodoEditPage() {
   }, []);
 
   useEffect(() => {
-    // 일정 내용 가져오는 api
-    form.setContent("임의의 내용");
-    form.setCategory({ name: "카테고리1", color: "blue" });
-    form.setStartDate(new Date());
-    form.setStartTime("11:00");
-    form.setIsTimeOn(true);
+    // 임시 데이터
+    const data: TodoScheduleFormData = {
+      content: "투두 내용",
+      category: { name: "카테고리1", color: "blue" },
+      startDate: new Date(),
+      startTime: "17:00",
+      isTimeOn: true,
+    };
+    setTodoScheduleForm(form, data);
   }, []);
 
   return (

--- a/src/pages/main/todo/new/MainTodoNewPage.tsx
+++ b/src/pages/main/todo/new/MainTodoNewPage.tsx
@@ -8,13 +8,12 @@ function MainTodoNewPage() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!form.validateContentAndCategory()) return;
-    console.log(form.content, form.category, form.startDate, form.startTime);
     // Todo 생성 api
   };
 
   useEffect(() => {
     // 카테고리 목록 가져오는 api
-    form.setCategoryList([
+    form.handleCategoryListChange([
       { name: "카테고리1", color: "blue" },
       { name: "카테고리2", color: "red" },
       { name: "카테고리3", color: "black" },

--- a/src/pages/main/todo/new/MainTodoNewPage.tsx
+++ b/src/pages/main/todo/new/MainTodoNewPage.tsx
@@ -26,6 +26,7 @@ function MainTodoNewPage() {
     <TodoScheduleForm
       form={form}
       onSubmit={handleSubmit}
+      withCategory={true}
       submitButtonText="생성"
     />
   );

--- a/src/pages/main/todo/new/MainTodoNewPage.tsx
+++ b/src/pages/main/todo/new/MainTodoNewPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
-import ScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
 
 function MainTodoNewPage() {
   const form = useTodoScheduleForm();
@@ -22,7 +22,11 @@ function MainTodoNewPage() {
   }, []);
 
   return (
-    <ScheduleForm form={form} onSubmit={handleSubmit} submitButtonText="생성" />
+    <TodoScheduleForm
+      form={form}
+      onSubmit={handleSubmit}
+      submitButtonText="생성"
+    />
   );
 }
 

--- a/src/pages/main/todo/new/MainTodoNewPage.tsx
+++ b/src/pages/main/todo/new/MainTodoNewPage.tsx
@@ -7,17 +7,19 @@ function MainTodoNewPage() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!form.validateContentAndCategory()) return;
+    if (!form.handleFormValidation()) return;
     // Todo 생성 api
   };
 
   useEffect(() => {
-    // 카테고리 목록 가져오는 api
-    form.handleCategoryListChange([
-      { name: "카테고리1", color: "blue" },
-      { name: "카테고리2", color: "red" },
-      { name: "카테고리3", color: "black" },
-    ]);
+    // 카테고리 목록을 업데이트
+    form.handleListUpdate({
+      categories: [
+        { name: "카테고리1", color: "blue" },
+        { name: "카테고리2", color: "red" },
+        { name: "카테고리3", color: "black" },
+      ],
+    });
   }, []);
 
   return (


### PR DESCRIPTION
## 구현 요약

- useTodoScheduleForm 훅으로 state 및 handler함수 관리
- 사용 예시
![22](https://github.com/user-attachments/assets/f71cc13a-392a-4242-95f0-9f77321fb73c)

- TodoScheduleForm으로 공통 레이아웃 관리
- 사용 예시
![11](https://github.com/user-attachments/assets/105b23c5-b7d8-49ff-bf3c-c0b9e57a25ff)

- 그룹 할일 생성 페이지 제작
- 그룹 할일 수정 페이지 제작
- 그룹 일정 생성 페이지 제작
- 그룹 일정 수정 페이지 제작

### 연관 이슈

close #79 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
