### PR TITLE
feat: 일정, 투두 컴포넌트 기능 구현

### DIFF
--- a/src/components/common/ScheduleList/ScheduleItem.style.tsx
+++ b/src/components/common/ScheduleList/ScheduleItem.style.tsx
@@ -1,20 +1,18 @@
 import styled from "styled-components";
 
 export const Wrapper = styled.div`
-  width: calc(100% - 2rem);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 5px;
-  margin: 0 auto;
-  padding: 0.5rem;
+  margin: 10px 0;
+  padding: 0.8rem;
   border-bottom: 1px solid #97cdbd;
 `;
 
 export const Explan = styled.div`
   width: 75%;
   display: flex;
-  gap: 7px;
+  gap: 0.6rem;
   align-items: center;
 `;
 

--- a/src/components/common/ScheduleList/ScheduleItem.tsx
+++ b/src/components/common/ScheduleList/ScheduleItem.tsx
@@ -1,29 +1,67 @@
 import * as Styled from "./ScheduleItem.style";
 import TextDate from "../TextDate/TextDate";
 import ListBar from "../ListBar/ListBar";
+import EditDeleteIcon from "@/components/feature/EditDeleteIcon/EditDeleteIcon";
+import { useNavigate } from "react-router-dom";
+import { FormatDate, FormatTime } from "@/utils/format";
 
 interface ScheduleItemProps {
-  values: string[]; // 날짜 or 시간 시작 및 종료
-  color: string;
-  schedule: string;
+  id: string; // 일정 id
+  title: string; // 일정 제목
+  startDate: string; // 시작 날짜
+  endDate: string; // 종료 날짜
+  startTime?: string | null; // 시작 시간
+  endTime?: string | null; // 종료 시간
+  isAlarmed: boolean; // 알림 여부
+  categoryId: string; // 카테고리 id
+  color: string; // 카테고리 색상
+  onDelete: (id: string) => void; // 삭제 핸들러
 }
 
-// 일정 아이템, props 값은 임시로 설정해뒀습니다.
-// values는 시작/종료 값을 넣어주면 됩니다.
-//  ex. ["1월 00일", "10월 50일"], ["1 : 00", "12 : 00"]
 function ScheduleItem({
-  values = [],
-  color = "#E1FBFF",
-  schedule = "기말고사",
+  id,
+  title,
+  startDate,
+  endDate,
+  startTime,
+  endTime,
+  isAlarmed,
+  categoryId,
+  color,
+  onDelete,
 }: ScheduleItemProps) {
+  const navigate = useNavigate();
+
+  // 수정 버튼 클릭
+  const handleEditClick = () => {
+    navigate(`/main/schedule/${id}/edit`, {
+      state: {
+        id,
+        title,
+        startDate,
+        endDate,
+        startTime,
+        endTime,
+        isAlarmed,
+        categoryId,
+      },
+    });
+  };
+
+  // values 설정 (날짜 or 시간)
+  const values =
+    startDate === endDate && startTime && endTime
+      ? [FormatTime(startTime), FormatTime(endTime)] // startDate와 endDate가 같고 startTime, endTime이 존재하면 시간 표시
+      : [FormatDate(startDate), FormatDate(endDate)]; // 그렇지 않으면 날짜 표시
+
   return (
     <Styled.Wrapper>
       <Styled.Explan>
-        {values.length > 0 ? <TextDate values={values} /> : ""}
+        <TextDate values={values} />
         <ListBar color={color} />
-        <Styled.ScheduleText>{schedule}</Styled.ScheduleText>
+        <Styled.ScheduleText>{title}</Styled.ScheduleText>
       </Styled.Explan>
-      <span>(수정 아이콘)</span>
+      <EditDeleteIcon onEdit={handleEditClick} onDelete={() => onDelete(id)} />
     </Styled.Wrapper>
   );
 }

--- a/src/components/common/TodoList/TodoItem.style.tsx
+++ b/src/components/common/TodoList/TodoItem.style.tsx
@@ -1,13 +1,11 @@
 import styled from "styled-components";
 
 export const Wrapper = styled.div`
-  width: calc(100% - 2rem);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 5px;
-  margin: 0 auto;
-  padding: 0.5rem;
+  margin: 10px 0;
+  padding: 0.8rem;
   border-bottom: 1px solid #97cdbd;
 `;
 
@@ -15,12 +13,14 @@ export const ExplanContainer = styled.div`
   min-width: 50%;
   display: flex;
   flex: 1;
-  gap: 7px;
+  gap: 1rem;
   align-items: center;
   overflow: hidden;
 `;
 
-export const TodoText = styled.p<{ isChecked: boolean }>`
+export const TodoText = styled.p.withConfig({
+  shouldForwardProp: (prop) => prop !== "isChecked",
+})<{ isChecked?: boolean }>`
   width: 100%;
   font-size: 1rem;
   overflow: hidden;
@@ -28,6 +28,7 @@ export const TodoText = styled.p<{ isChecked: boolean }>`
   text-overflow: ellipsis;
   word-break: break-all;
   text-decoration: ${(props) => (props.isChecked ? "line-through" : "none")};
+  color: ${(props) => (props.isChecked ? "gray" : "black")};
 `;
 
 export const SetContainer = styled.div`
@@ -51,8 +52,34 @@ export const AssignPeople = styled.span<{ isMemDone: boolean }>`
 `;
 
 export const CheckboxCustom = styled.input.attrs({ type: "checkbox" })`
+  /* 기본 체크박스 숨기기 */
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+
+  /* 커스텀 스타일 */
   width: 17px;
   height: 17px;
   border: 1px solid #97cdbd;
-  accent-color: #97cdbd; // 체크 됐을 때의 색상
+  border-radius: 3px; /* 선택 사항: 둥근 모서리 */
+  background-color: transparent;
+  cursor: pointer;
+
+  /* 체크된 상태 스타일 */
+  &:checked {
+    background-color: #97cdbd; /* 배경색 */
+    position: relative;
+  }
+
+  /* 체크 표시 */
+  &:checked::after {
+    content: "✓"; /* 체크 표시 */
+    font-size: 14px; /* 체크 표시 크기 */
+    color: #ffffff; /* 체크 표시 색상 */
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
 `;

--- a/src/components/common/TodoList/TodoItem.tsx
+++ b/src/components/common/TodoList/TodoItem.tsx
@@ -1,53 +1,66 @@
 import * as Styled from "./TodoItem.style";
 import useTodoItem from "@/hooks/useTodoItem";
-import TextDate from "../TextDate/TextDate";
 import ListBar from "../ListBar/ListBar";
+import EditDeleteIcon from "@/components/feature/EditDeleteIcon/EditDeleteIcon";
+import { useNavigate } from "react-router-dom";
+import TextDate from "../TextDate/TextDate";
+import { FormatTime } from "@/utils/format";
 
-interface GroupMember {
-  name: string; // 이름
-  process: boolean; // todo 완료 상태
-}
 interface TodoItemProps {
-  values: string[];
-  color: string;
-  todo: string;
-  isComplete: boolean;
-  isMember: GroupMember[];
+  id: string; // ID
+  title: string; // 투두 제목
+  date: string; // 날짜
+  startTime?: string | null; // 시작 시간 (옵션)
+  done: boolean; // 완료 여부
+  categoryId: string; // 카테고리 ID
+  color: string; // 카테고리 색상
+  onDelete: (id: string) => void; // 삭제 핸들러
 }
+
 function TodoItem({
-  values = [],
-  color = "#EBFFE1",
-  todo = "기말고사기말고사기말고사기말기말고사기말고사기말고사기말",
-  isComplete = false,
-  isMember = [],
+  id,
+  title,
+  date,
+  startTime,
+  done,
+  categoryId,
+  color,
+  onDelete,
 }: TodoItemProps) {
-  const { isChecked, toggleChecked } = useTodoItem({ isComplete });
+  const { isChecked, toggleChecked } = useTodoItem({ isComplete: done });
+
+  const navigate = useNavigate();
+
+  // 수정 버튼 핸들러 (수정 페이지랑 연결되는거 나중에 수정해야함)
+  const handleEditClick = () => {
+    navigate(`/main/todo/${id}/edit`, {
+      state: { id, title, date, startTime, categoryId },
+    });
+  };
 
   return (
     <Styled.Wrapper>
+      {startTime && <TextDate values={[FormatTime(startTime)]} />}
       <Styled.ExplanContainer>
-        {values.length > 0 ? <TextDate values={values} /> : ""}
         <ListBar color={color} />
-        <Styled.TodoText isChecked={isChecked}>{todo}</Styled.TodoText>
+        <Styled.TodoText isChecked={isChecked}>{title}</Styled.TodoText>
       </Styled.ExplanContainer>
       <Styled.SetContainer>
-        {isMember.length ? (
-          <Styled.AssignWrapper>
-            {isMember.map((people: GroupMember) => (
-              <Styled.AssignPeople isMemDone={people.process}>
-                {people.name}{" "}
-              </Styled.AssignPeople>
-            ))}
-          </Styled.AssignWrapper>
-        ) : (
-          ""
-        )}
+        <Styled.AssignWrapper>
+          {/* 나중에 팀원 목록 쓰는 구간 */}
+          {/* <Styled.AssignPeople isMemDone={true}>이가영</Styled.AssignPeople> */}
+        </Styled.AssignWrapper>
+        {/* 투두 체크 박스 */}
         <Styled.CheckboxCustom
           type="checkbox"
           checked={isChecked}
           onChange={toggleChecked}
         />
-        <span>(아이콘)</span>
+        {/* 수정/삭제 모달 아이콘 */}
+        <EditDeleteIcon
+          onEdit={handleEditClick}
+          onDelete={() => onDelete(id)}
+        />
       </Styled.SetContainer>
     </Styled.Wrapper>
   );

--- a/src/components/feature/CategoryList/CategoryList.tsx
+++ b/src/components/feature/CategoryList/CategoryList.tsx
@@ -1,11 +1,7 @@
-import { useState, useEffect, useRef } from "react";
 import Circle from "@/components/common/Circle/Circle";
-import DotsIcon from "@/assets/icons/dots.svg?react";
 import * as Styled from "./CategoryList.style";
-import EditDeleteModal from "@/components/common/EditDeleteModal/EditDeleteModal";
-
 import { useNavigate } from "react-router-dom";
-import DeleteConfirm from "@/components/common/DeleteConfirm/DeleteConfirm";
+import EditDeleteIcon from "../EditDeleteIcon/EditDeleteIcon";
 
 interface CategoryListProps {
   categoryId: number;
@@ -14,59 +10,18 @@ interface CategoryListProps {
 }
 
 function CategoryList({ categoryId, color, name }: CategoryListProps) {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const modalRef = useRef<HTMLDivElement>(null);
-  const iconRef = useRef<HTMLDivElement>(null);
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-
   const navigate = useNavigate();
 
-  // DotsIcon 클릭 시 모달 열기
-  const handleDotsClick = () => {
-    setIsModalOpen((prev) => !prev); // 현재 상태를 반전시켜 모달 열거나 닫기
-  };
-
-  // 모달 외부 클릭 시 모달 닫기 함수
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        modalRef.current &&
-        !modalRef.current.contains(event.target as Node) &&
-        iconRef.current &&
-        !iconRef.current.contains(event.target as Node)
-      ) {
-        setIsModalOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
-
-  // 수정 버튼 클릭 시 해당 카테고리 수정 페이지로 이동
+  // 수정 버튼 클릭
   const handleEditClick = () => {
     navigate(`/categories/${categoryId}/edit`, {
       state: { categoryId, color, name },
     });
-    setIsModalOpen(false);
   };
 
-  // 삭제 버튼 클릭 시 삭제 확인 모달
+  // 삭제 버튼 클릭
   const handleDeleteClick = () => {
-    setIsModalOpen(false);
-    setIsDeleteConfirmOpen(true); // 삭제 확인 모달 열기
-  };
-
-  // 삭제 취소로 모달 닫기
-  const handleCloseDeleteConfirm = () => {
-    setIsDeleteConfirmOpen(false);
-  };
-
-  // 삭제 확인 모달에서 진짜 삭제
-  const handleConfirmDelete = () => {
-    setIsDeleteConfirmOpen(false);
+    console.log(categoryId);
     // 실제 삭제 로직 추가
   };
 
@@ -77,34 +32,7 @@ function CategoryList({ categoryId, color, name }: CategoryListProps) {
           <Circle color={color} />
           {name}
         </Styled.LeftSection>
-        <Styled.RightIcon ref={iconRef} onClick={handleDotsClick}>
-          <DotsIcon
-            width={20}
-            height={20}
-            fill="currentColor"
-            stroke="currentColor"
-          />
-        </Styled.RightIcon>
-        {isModalOpen && (
-          <div
-            ref={modalRef}
-            style={{ position: "absolute", top: "100%", right: 0, zIndex: 999 }}
-          >
-            <EditDeleteModal
-              top={-10}
-              left={-55}
-              onClickEdit={handleEditClick}
-              onClickDelete={handleDeleteClick}
-            />
-          </div>
-        )}
-        {isDeleteConfirmOpen && (
-          <DeleteConfirm
-            text="정말로 삭제하시겠습니까?"
-            onClickCancel={handleCloseDeleteConfirm}
-            onClickDelete={handleConfirmDelete}
-          />
-        )}
+        <EditDeleteIcon onEdit={handleEditClick} onDelete={handleDeleteClick} />
       </Styled.CategoryContainer>
     </>
   );

--- a/src/components/feature/EditDeleteIcon/EditDelete.style.ts
+++ b/src/components/feature/EditDeleteIcon/EditDelete.style.ts
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+
+export const RightIcon = styled.div`
+  margin-left: auto;
+  color: var(--color-gray-light);
+  transition: color 0.25s ease;
+  cursor: pointer;
+  position: relative;
+  &:hover {
+    color: var(--color-gray-dark);
+  }
+`;

--- a/src/components/feature/EditDeleteIcon/EditDeleteIcon.tsx
+++ b/src/components/feature/EditDeleteIcon/EditDeleteIcon.tsx
@@ -1,0 +1,99 @@
+import { useState, useEffect, useRef } from "react";
+import DotsIcon from "@/assets/icons/dots.svg?react";
+import EditDeleteModal from "@/components/common/EditDeleteModal/EditDeleteModal";
+import DeleteConfirm from "@/components/common/DeleteConfirm/DeleteConfirm";
+import * as Styled from "./EditDelete.style";
+
+interface EditDeleteIconProps {
+  onEdit: () => void; // 수정 동작
+  onDelete: () => void; // 삭제 동작
+}
+
+function EditDeleteIcon({ onEdit, onDelete }: EditDeleteIconProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false); // 삭제 확인 모달 상태
+  const modalRef = useRef<HTMLDivElement>(null);
+  const iconRef = useRef<HTMLDivElement>(null);
+
+  // 아이콘 클릭 시 모달 열기/닫기
+  const handleIconClick = () => {
+    setIsModalOpen((prev) => !prev);
+  };
+
+  // 수정 버튼 클릭
+  const handleEditClick = () => {
+    onEdit(); // 상위 컴포넌트로 수정 동작 전달
+    setIsModalOpen(false); // 수정 후 모달 닫기
+  };
+
+  // 삭제 버튼 클릭
+  const handleDeleteClick = () => {
+    setIsModalOpen(false); // 수정 모달 닫기
+    setIsDeleteConfirmOpen(true); // 삭제 확인 모달 열기
+  };
+
+  // 삭제 확인 모달 닫기
+  const handleCloseDeleteConfirm = () => {
+    setIsDeleteConfirmOpen(false);
+  };
+
+  // 삭제 확인 모달에서 실제 삭제
+  const handleConfirmDelete = () => {
+    onDelete(); // 상위 컴포넌트로 삭제 동작 전달
+    setIsDeleteConfirmOpen(false); // 삭제 확인 모달 닫기
+  };
+
+  // 모달 외부 클릭 시 모달 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node) &&
+        iconRef.current &&
+        !iconRef.current.contains(event.target as Node)
+      ) {
+        setIsModalOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div style={{ position: "relative" }}>
+      <Styled.RightIcon ref={iconRef} onClick={handleIconClick}>
+        <DotsIcon
+          width={20}
+          height={20}
+          fill="currentColor"
+          stroke="currentColor"
+        />
+      </Styled.RightIcon>
+      {isModalOpen && (
+        <div
+          ref={modalRef}
+          style={{ position: "absolute", top: "100%", right: 0, zIndex: 999 }}
+        >
+          <EditDeleteModal
+            top={0}
+            left={-55}
+            onClickEdit={handleEditClick}
+            onClickDelete={handleDeleteClick}
+          />
+        </div>
+      )}
+      {isDeleteConfirmOpen && (
+        <DeleteConfirm
+          text="정말로 삭제하시겠습니까?"
+          onClickCancel={handleCloseDeleteConfirm}
+          onClickDelete={handleConfirmDelete}
+        />
+      )}
+    </div>
+  );
+}
+
+export default EditDeleteIcon;

--- a/src/components/feature/MainCategoryButton/MainCategoryButton.style.ts
+++ b/src/components/feature/MainCategoryButton/MainCategoryButton.style.ts
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+`;
+
+export const Button = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    transform: scale(1.1);
+    transition: transform 0.25s ease;
+  }
+`;

--- a/src/components/feature/MainCategoryButton/MainCategoryButton.tsx
+++ b/src/components/feature/MainCategoryButton/MainCategoryButton.tsx
@@ -1,0 +1,23 @@
+import SettingIcon from "@/assets/icons/setting.svg?react";
+import FilterIcon from "@/assets/icons/filtering.svg?react";
+import * as Styled from "./MainCategoryButton.style";
+import { useNavigate } from "react-router-dom";
+
+function MainCategoryButton() {
+  const navigate = useNavigate();
+  const handleClick = () => {
+    navigate("/categories");
+  };
+  return (
+    <Styled.Container>
+      <Styled.Button onClick={handleClick}>
+        <SettingIcon width={20} height={20} fill="none" stroke="currentColor" />
+      </Styled.Button>
+      <Styled.Button>
+        <FilterIcon width={20} height={20} fill="none" stroke="currentColor" />
+      </Styled.Button>
+    </Styled.Container>
+  );
+}
+
+export default MainCategoryButton;

--- a/src/components/feature/PlusButton/PlusButton.style.ts
+++ b/src/components/feature/PlusButton/PlusButton.style.ts
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--color-black);
+  font-weight: var(--font-weight-bold);
+  padding: 0.5rem;
+  margin: 1rem 0;
+`;
+
+export const IconWrapper = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    transform: scale(1.1);
+    transition: transform 0.2s ease;
+  }
+`;

--- a/src/components/feature/PlusButton/PlusButton.tsx
+++ b/src/components/feature/PlusButton/PlusButton.tsx
@@ -1,0 +1,25 @@
+import PlusIcon from "@/assets/icons/plus.svg?react";
+import * as Styled from "./PlusButton.style";
+
+interface PlusButtonProps {
+  label?: string; // 버튼에 표시될 텍스트
+  onClick?: () => void; // 버튼 클릭 핸들러
+}
+
+function PlusButton({ label = "버튼", onClick }: PlusButtonProps) {
+  return (
+    <Styled.Container>
+      <span>{label}</span>
+      <Styled.IconWrapper onClick={onClick}>
+        <PlusIcon
+          width={20}
+          height={20}
+          fill="currentColor"
+          stroke="currentColor"
+        />
+      </Styled.IconWrapper>
+    </Styled.Container>
+  );
+}
+
+export default PlusButton;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,11 @@
+// 날짜
+export const FormatDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+};
+
+// 시간
+export const FormatTime = (timeString: string | null): string => {
+  if (!timeString) return "-";
+  return `${timeString.slice(0, 2)}시 ${timeString.slice(3, 5)}분`;
+};


### PR DESCRIPTION
## 구현 요약

### 수정, 삭제 모달 아이콘 컴포넌트로 수정
수정 페이지 개발 부분에 맞춰서 나중에 수정필요
현재는 수정페이지로 이동만 가능 
삭제도 현재 ui 상으로만 삭제된 것. 나중에 삭제 구현 필요

### 카테고리 설정, 필터링 버튼 컴포넌트 생성
카테고리 설정 페이지로 이동은 구현
카테고리 필터링 버튼은 미구현 

### 투두 , 일정 생성 버튼 컴포넌트
각 투두, 일정 생성 페이지로 이동하게 구현

### 투두, 일정 컴포넌트 코드 수정
api 에서 받는 데이터 형식에 맞춰서 수정

### 날짜, 시간 포맷 추가
2024-12-26 => 12월 26일
18:00:00 => 18시 00분

### 연관 이슈

- ex) close #83 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
