### PR TITLE
feat: mainpage 구현

### DIFF
--- a/src/components/feature/CategoryList/CategoryList.style.ts
+++ b/src/components/feature/CategoryList/CategoryList.style.ts
@@ -18,14 +18,3 @@ export const LeftSection = styled.div`
   align-items: center;
   gap: 4px;
 `;
-
-export const RightIcon = styled.div`
-  margin-left: auto;
-  color: var(--color-gray-light);
-  transition: color 0.25s ease;
-  cursor: pointer;
-  position: relative;
-  &:hover {
-    color: var(--color-gray-dark);
-  }
-`;

--- a/src/components/feature/CatergoryForm/CategoryForm.style.ts
+++ b/src/components/feature/CatergoryForm/CategoryForm.style.ts
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 
 export const Container = styled.form`
-  padding: 6rem 2rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/components/feature/MainList/MainList.style.ts
+++ b/src/components/feature/MainList/MainList.style.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const CategoryHeader = styled.div`
+  padding: 10px;
+  font-weight: bold;
+  font-size: 16px;
+  color: #fff;
+  border-radius: 5px;
+  margin-bottom: 8px;
+`;

--- a/src/components/feature/MainList/MainList.tsx
+++ b/src/components/feature/MainList/MainList.tsx
@@ -1,0 +1,116 @@
+import ScheduleItem from "@/components/common/ScheduleList/ScheduleItem";
+import PlusButton from "../PlusButton/PlusButton";
+import TodoItem from "@/components/common/TodoList/TodoItem";
+import MainCategoryButton from "../MainCategoryButton/MainCategoryButton";
+import { useNavigate } from "react-router-dom";
+import SortedTodo from "@/utils/sortedTodo";
+import SortedSchedule from "@/utils/sortedSchedule";
+
+interface MainListProps {
+  schedules: {
+    personalEventId: string;
+    title: string;
+    startDate: string;
+    endDate: string;
+    startTime: string | null;
+    endTime: string | null;
+    isAlarmed: boolean;
+    categoryId: string;
+    createdAt: string;
+  }[];
+  todos: {
+    personalTodoId: string;
+    title: string;
+    date: string;
+    done: boolean;
+    startTime: string | null;
+    categoryId: string;
+    createdAt: string;
+  }[];
+  categories: {
+    id: string;
+    name: string;
+    color: string;
+  }[];
+  onDelete: (type: "todo" | "schedule", id: string) => void;
+}
+
+function MainList({ schedules, todos, categories, onDelete }: MainListProps) {
+  const navigate = useNavigate();
+
+  // 카테고리 id를 키로 하는 카테고리 데이터 맵
+  const categoryMap = categories.reduce(
+    (acc, category) => {
+      acc[category.id] = category;
+      return acc;
+    },
+    {} as Record<string, { name: string; color: string }>
+  );
+
+  // 선택 날짜 데이터 임시 설정 (달력에서 받은 값으로 수정 필요)
+  const selectedDate = "2024-12-02";
+
+  // 선택 날짜 필터링 스케줄
+  const filteredSchedules = schedules.filter(
+    (schedule) =>
+      selectedDate >= schedule.startDate && selectedDate <= schedule.endDate
+  );
+
+  // 선택 날짜 필터링 투두
+  const filteredTodos = todos.filter((todo) => todo.date === selectedDate);
+
+  // 정렬된 일정
+  const sortedSchedules = SortedSchedule(filteredSchedules);
+
+  // 정렬된 투두
+  const sortedTodos = SortedTodo(filteredTodos);
+
+  return (
+    <>
+      {/* 카테고리 설정/필터 버튼 */}
+      <MainCategoryButton />
+      {/* 일정 + 버튼*/}
+      <PlusButton label="일정" onClick={() => navigate("/main/schedule/new")} />
+      {/* 일정 리스트 */}
+      {sortedSchedules.map((schedule) => {
+        const category = categoryMap[schedule.categoryId];
+        return (
+          <ScheduleItem
+            key={schedule.personalEventId}
+            id={schedule.personalEventId}
+            title={schedule.title}
+            startDate={schedule.startDate}
+            endDate={schedule.endDate}
+            startTime={schedule.startTime}
+            endTime={schedule.endTime}
+            isAlarmed={schedule.isAlarmed}
+            categoryId={schedule.categoryId}
+            color={category?.color || "gray"}
+            onDelete={() => onDelete("schedule", schedule.personalEventId)}
+          />
+        );
+      })}
+      {/* 투두 생성 버튼 */}
+      <PlusButton label="투두" onClick={() => navigate("/main/todo/new")} />
+      {/* 투두 리스트 */}
+      {sortedTodos.map((todo) => {
+        const category = categoryMap[todo.categoryId];
+        return (
+          <TodoItem
+            key={todo.personalTodoId}
+            id={todo.personalTodoId}
+            title={todo.title}
+            date={todo.date}
+            startTime={todo.startTime}
+            done={todo.done}
+            categoryId={todo.categoryId}
+            color={category?.color || "gray"}
+            onDelete={() => onDelete("todo", todo.personalTodoId)}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+export default MainList;

--- a/src/pages/categories/CategoriesPage.style.ts
+++ b/src/pages/categories/CategoriesPage.style.ts
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 
 export const Container = styled.div`
-  padding: 6rem 2rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,5 +1,51 @@
+// import CalendarMonth from "@/components/common/Calendar/Calendar";
+import { useState } from "react";
+import MainList from "@/components/feature/MainList/MainList";
+import { PERSONAL_EVENT_DATA } from "@/mocks/PERSONAL_EVENT_DATA";
+import { PERSONAL_TODO_DATA } from "@/mocks/PERSONAL_TODO_DATA";
+
 function MainPage() {
-  return <div>MainPage</div>;
+  const [todos, setTodos] = useState(PERSONAL_TODO_DATA);
+  const [schedules, setSchedules] = useState(PERSONAL_EVENT_DATA);
+  const [categories] = useState([
+    // 카테고리 임시 데이터
+    {
+      id: "34a81a0e-f886-43f2-a984-194ba77eab1d",
+      name: "카테고리1",
+      color: "blue",
+    },
+    {
+      id: "e86193f9-3a85-49fc-9604-10eee8641b5a",
+      name: "카테고리2",
+      color: "green",
+    },
+  ]);
+
+  // 공통 삭제 함수 (그냥 화면에서만 보여지는 함수 나중에 삭제 구현해야함 !)
+  const handleDelete = (type: "todo" | "schedule", id: string) => {
+    if (type === "todo") {
+      setTodos((prevTodos) =>
+        prevTodos.filter((todo) => todo.personalTodoId !== id)
+      );
+    } else if (type === "schedule") {
+      setSchedules((prevSchedules) =>
+        prevSchedules.filter((schedule) => schedule.personalEventId !== id)
+      );
+    }
+  };
+
+  return (
+    <div>
+      {/* 달력 수정 필요  */}
+      {/* <CalendarMonth /> */}
+      <MainList
+        schedules={schedules} // 일정 데이터 전달
+        todos={todos} // // 카테고리 데이터 전달
+        categories={categories} // 카테고리 데이터 전달
+        onDelete={handleDelete}
+      />
+    </div>
+  );
 }
 
 export default MainPage;

--- a/src/utils/sortedSchedule.ts
+++ b/src/utils/sortedSchedule.ts
@@ -1,0 +1,43 @@
+interface Schedule {
+  personalEventId: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  startTime?: string | null;
+  endTime?: string | null;
+  isAlarmed: boolean;
+  categoryId: string;
+  createdAt: string;
+}
+
+/**
+ * 스케줄 리스트 정렬 훅
+ * - `endDate`가 현재 날짜와 가까운 순서대로 정렬
+ * - `startDate`와 `startTime` 기준으로 정렬
+ */
+function SortedSchedule(schedules: Schedule[]): Schedule[] {
+  const currentDate = new Date();
+
+  return schedules.slice().sort((a, b) => {
+    const endDateDiffA = new Date(a.endDate).getTime() - currentDate.getTime();
+    const endDateDiffB = new Date(b.endDate).getTime() - currentDate.getTime();
+
+    // 1. `endDate` 기준 정렬
+    if (endDateDiffA !== endDateDiffB) {
+      return endDateDiffA - endDateDiffB;
+    }
+
+    // 2. `startDate`와 `startTime` 기준 정렬
+    if (a.startDate === b.startDate) {
+      if (a.startTime && b.startTime) {
+        return a.startTime.localeCompare(b.startTime); // 문자열 시간 비교
+      }
+      if (a.startTime) return -1; // `a`가 먼저 실행
+      if (b.startTime) return 1; // `b`가 먼저 실행
+    }
+
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+}
+
+export default SortedSchedule;

--- a/src/utils/sortedTodo.ts
+++ b/src/utils/sortedTodo.ts
@@ -1,0 +1,37 @@
+interface Todo {
+  personalTodoId: string;
+  title: string;
+  date: string;
+  startTime?: string | null; // "HH:mm:ss" 형식 또는 null
+  done: boolean;
+  categoryId: string;
+  createdAt: string;
+}
+
+/**
+ * 투두 리스트 정렬
+ * - `done`이 `true`인 항목은 맨 아래로 이동
+ * - `startTime`이 있는 항목은 시간 순으로 정렬
+ * - `startTime`이 없는 항목은 뒤로 배치
+ * - 동일한 조건일 경우 `createdAt` 최신 순서대로 정렬
+ */
+function SortedTodo(todos: Todo[]): Todo[] {
+  return todos.slice().sort((a, b) => {
+    // 1. `done` 기준 정렬 (false가 우선)
+    if (a.done !== b.done) {
+      return a.done ? 1 : -1;
+    }
+
+    // 2. `startTime` 기준 정렬
+    if (a.startTime && b.startTime) {
+      return a.startTime.localeCompare(b.startTime); // 문자열 시간 비교
+    }
+    if (!a.startTime) return 1; // a가 null이면 b 우선
+    if (!b.startTime) return -1; // b가 null이면 a 우선
+
+    // 3. 동일한 조건일 경우 `createdAt` 최신 순서대로 정렬
+    return b.createdAt.localeCompare(a.createdAt); // 최신순
+  });
+}
+
+export default SortedTodo;


### PR DESCRIPTION
## 구현 요약

### 투두, 일정 정렬 
sortedSchedule, sortedTodo 파일에 리스트 정렬부분을 따로 정리했습니다 

### MainList 컴포넌트
투두리스트, 일정리스트가 다 포함된 리스트 컴포넌트 구현했습니다 
현재는 선택 날짜를 임시로 설정해서 선택된 날짜로 데이터들을 필터링 되게 만들었습니다
이부분은 추후에 날짜를 기준으로 일별 데이터를 불러올 수 있는 api 연결해서 사용하면 될 것 같습니다 


### 메인페이지
카테고리는 임시 데이터로 넣어둬서 사용했습니다 
마찬가지로 삭제도 ui 상으로만 삭제되어 보이고 삭제부분은 나중에 구현 필요합니다 
그리고 달력부분은 주석처리 해두어서 주석 풀어서 사용하시면 됩니다 

### 연관 이슈

이 부분을 제거하고 연관된 이슈를 아래와 같이 명시해 닫아주세요.

- ex) close #12

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
