### PR TITLE
fix: routes파일 groupEdit  오류 수정

### DIFF
--- a/src/pages/group/edit/GroupEditPage.tsx
+++ b/src/pages/group/edit/GroupEditPage.tsx
@@ -5,11 +5,12 @@ import MemberList from "@/components/feature/GroupNewPage/MemberList";
 import useGroupEditForm from "@/hooks/useGroupEditForm";
 
 interface GroupEditPageProps {
-  groupName: string;
-  color: string;
+  groupName?: string;
+  color?: string;
 }
 
 // 수정 페이지에서는 color랑 description 만 변경됨.
+// 데이터를 props를 통해 받게 되어있는데, useParam or useLocation에 맞춰 추후 수정 필요
 function GroupEditPage({
   groupName = "DBDB DEEP",
   color = "#c9c9c9",


### PR DESCRIPTION
## 구현 요약

`routes.tsx` 파일에 `GroupEditPage`에 props 오류가 떠서 안 뜨도록 해결했습니다.

추후 개발에 맞춰 `useParams` 또는 `useLocation` 을 사용해서 데이터를 전달받을 것 같고, 그에 맞춰 수정도 필요합니다.

### 연관 이슈

-  close #95 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
