### PR TITLE
hotfix: yarn build 오류 수정

### DIFF
--- a/src/components/common/Calendar/Calendar.tsx
+++ b/src/components/common/Calendar/Calendar.tsx
@@ -23,9 +23,8 @@ function Calendar({ usage, onDateSelect }: CalendarProps) {
     onDateSelect(arg.date);
   };
 
-  
   if (isLoading) return <div>Loading...</div>;
-  if (error) return <div>Error: {error}</div>;
+  if (error) return <div>Error: {error.message}</div>;
 
   return (
     <div

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -42,7 +42,8 @@ export function useCalendar(usage: "main" | "group") {
     data: personalTodos = [],
     isLoading: isPersonalTodosLoading,
     error: personalTodosError,
-  } = usePersonalTodos();
+    // 아래의 usePersonalTodos 매개변수 dateParams가 비어있으면 오류가 떠서 임시로 값을 넣었습니다. 수정필요!
+  } = usePersonalTodos({ year: 2024, month: 12 });
   const {
     data: personalGroupSchedules = [],
     isLoading: isPersonalGroupSchedulesLoading,

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -2,7 +2,7 @@ import useSignupForm from "@/hooks/useSignupForm";
 import * as Styled from "./SignupPage.style";
 import TextInput from "@/components/common/TextInput/TextInput";
 import Button from "@/components/common/Button/Button";
-import Camera from "@/assets/icons/Camera.svg?react";
+import Camera from "@/assets/icons/camera.svg?react";
 
 function SignupPage() {
   const { formData, handleChange, handleImageChange, handleSubmit } =


### PR DESCRIPTION
## 구현 요약
- svg import 시 대소문자 오류 수정 (yarn build시 svg 대소문자는 에러 메세지로 나타나지 않아서 추가로 알려주시면 수정하겠습니다.)
- `common/Calendar/Calendar.tsx` 에서 {error} -> {error.message} 로 수정
- 임시로 만들어둔 `usePersonalTodos.ts`에서 매개변수 값이 `src/hooks/useCalendar.ts`에서 필요하다고 나타나서 임시 값을 아래와 같이 넣어두었습니다.

```tsx
  const {
    data: personalTodos = [],
    isLoading: isPersonalTodosLoading,
    error: personalTodosError,
    // 아래의 usePersonalTodos 매개변수 dateParams가 비어있으면 오류가 떠서 임시로 값을 넣었습니다. 수정필요!
  } = usePersonalTodos({ year: 2024, month: 12 });
```

### 연관 이슈

- close #105 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
