### PR TITLE
design: 그룹이 없을 경우 페이지 퍼블리싱

### DIFF
--- a/src/pages/group/noData/GroupNoData.style.ts
+++ b/src/pages/group/noData/GroupNoData.style.ts
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 30px;
+  margin-top: 30%;
+`;
+
+export const Explan = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  font-weight: var(--font-weight-bold);
+`;

--- a/src/pages/group/noData/GroupNoData.tsx
+++ b/src/pages/group/noData/GroupNoData.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import * as Styled from "./GroupNoData.style";
+import Button from "@/components/common/Button/Button";
+
+function GroupNoData() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // 여기서 사용자의 그룹이 있는지 확인 (그룹 조회 api)
+    // 그룹이 있다면 ->그룹 페이지로 렌더링
+    // if () {
+    // navigate("/group/1");
+    // }
+    // 그룹이 없다면 -> 현재 페이지 렌더링
+  }, []);
+  return (
+    <Styled.Wrapper>
+      <Styled.Explan>
+        <p>그룹이 없습니다.</p>
+        <p>그룹을 만들고 함께 목표를 달성해보세요!</p>
+      </Styled.Explan>
+      <Button
+        children="그룹 만들기"
+        buttonType="primaryLarge"
+        type="button"
+        onClick={() => navigate("./new")}
+      />
+    </Styled.Wrapper>
+  );
+}
+
+export default GroupNoData;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,6 +8,7 @@ import MainPage from "@/pages/main/MainPage";
 import MyPage from "@/pages/mypage/MyPage";
 import MyEditPage from "@/pages/mypage/edit/MyEditPage";
 import ChatPage from "@/pages/chat/ChatPage";
+import GroupNoData from "@/pages/group/noData/GroupNoData";
 import GroupPage from "@/pages/group/GroupPage";
 import GroupNewPage from "@/pages/group/new/GroupNewPage";
 import GroupEditPage from "@/pages/group/edit/GroupEditPage";
@@ -82,7 +83,8 @@ export const router = createBrowserRouter([
           // group 페이지로 이동 전에 어떤 아이디로 보낼지 결정해서 그 경로로 navigate 하는 방법도 있습니다.
           // /group 경로 - 그룹 없을 때 '새 그룹을 생성해 보세요' 페이지
           // /group으로 접근 시 속한 그룹이 있거나, 마지막 열람한 그룹 정보가 있으면 navigate
-          { index: true, element: <GroupNewPage /> },
+          // { index: true, element: <GroupNoData /> },
+          { path: "", element: <GroupNoData /> },
           // group/schedule, group/todo 를 :groupId로 인식해서 생기는 버그 해결
           { path: "schedule/*", element: <Navigate to="/" replace /> },
           { path: "todo/*", element: <Navigate to="/" replace /> },


### PR DESCRIPTION
## 구현 요약

- 그룹이 경을 경우 보여줄 페이지
<img width="1155" alt="image" src="https://github.com/user-attachments/assets/64cbcee7-640b-49db-b2c1-6766266bf5d0">

하단 nav 바에서 그룹을 누르게 되면 `/group`으로 이동하게 됩니다.
(적용 X) 이때 그룹 조회 api를 사용하고 그룹이 있다면 `navigate('/group/1')`으로 이동하도록 해두었습니다. 
이는 `useEffect`로 우선 작성 해두었고, 주석처리 해두었습니다.


### 연관 이슈

- close #104 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
