### PR TITLE
design: 그룹 수정/생성 페이지 디자인 수정

### DIFF
--- a/src/components/feature/GroupNewPage/MemberList.style.ts
+++ b/src/components/feature/GroupNewPage/MemberList.style.ts
@@ -6,6 +6,16 @@ export const Wrapper = styled.div`
   gap: 20px;
 `;
 
+export const AddMemContainer = styled.div`
+  position: relative;
+
+  > button {
+    position: absolute;
+    right: 0px;
+    top: 50%;
+  }
+`;
+
 export const InfoContainer = styled.div`
   display: flex;
   align-items: center;

--- a/src/components/feature/GroupNewPage/MemberList.tsx
+++ b/src/components/feature/GroupNewPage/MemberList.tsx
@@ -1,25 +1,73 @@
+import { useState } from "react";
 import * as Styled from "./MemberList.style";
-import Plus from "@/assets/icons/plus.svg?react";
+// import Plus from "@/assets/icons/plus.svg?react";
 import Profile from "@/assets/icons/profile.svg?react";
 import Trashcan from "@/assets/icons/trashcan.svg?react";
+import TextInput from "@/components/common/TextInput/TextInput";
+import Button from "@/components/common/Button/Button";
+import { toast } from "react-toastify";
 
 // css 해야됨.
 function MemberList() {
+  const [nickname, setNickname] = useState("");
+  const [memberList, setMemberList] = useState<string[]>([]);
+
+  const handleChange = (value: string) => {
+    setNickname(value);
+    console.log(value);
+  };
+
+  const handleSubmit = () => {
+    console.log(nickname); // 닉네임 출력
+    toast.success(`${nickname}에게 초대 메세지를 보냈습니다!`);
+    setNickname(""); // 닉네임 초기화
+    setMemberList((prev) => [...prev, nickname]);
+  };
+
   return (
     <Styled.Wrapper>
-      <Styled.InfoContainer>
-        <p>팀원 목록</p>
+      {/* <Styled.InfoContainer>
         <Plus width={17} height={17} stroke="#676767" />
-      </Styled.InfoContainer>
+      </Styled.InfoContainer> */}
+      <Styled.AddMemContainer>
+        <TextInput
+          name="member"
+          type="text"
+          label="팀원 추가"
+          placeholder="팀원의 닉네임을 입력하고 한 번에 한 명씩 초대해주세요."
+          required
+          value={nickname}
+          onChange={handleChange}
+        />
+        <Button
+          children="초대"
+          buttonType="whiteMicro"
+          type="button"
+          onClick={handleSubmit}
+        />
+      </Styled.AddMemContainer>
 
+      {/* 현재 누구에게 초대를 보냈는지는 toast 메세지로 띄워주는 상황
+       *** 그래서 초대장을 보내기만 하면 팀원 목록이 (수락 여부와 상관없이) 나타남
+       *** 이는 알맞는 방법이 아닌 것 같음
+       *** -> 팀원 목록은 "그룹원 조회 api"를 사용해서 보여주는게 맞지 않을까 싶음
+       */}
+      <p>팀원 목록</p>
       <Styled.UserWrapper>
-        <Styled.UserInfoContainer>
-          <Styled.UserInfo>
-            <Profile width={25} height={25} stroke="#97CDBD" fill="#97CDBD" />
-            <p>팀원 1</p>
-          </Styled.UserInfo>
-          <Trashcan width={16} height={16} stroke="#B1B1B1" cursor="pointer" />
-        </Styled.UserInfoContainer>
+        {memberList.map((name) => (
+          <Styled.UserInfoContainer>
+            <Styled.UserInfo>
+              <Profile width={25} height={25} stroke="#97CDBD" fill="#97CDBD" />
+              <p>{name}</p>
+            </Styled.UserInfo>
+            <Trashcan
+              width={16}
+              height={16}
+              stroke="#B1B1B1"
+              cursor="pointer"
+            />
+          </Styled.UserInfoContainer>
+        ))}
       </Styled.UserWrapper>
     </Styled.Wrapper>
   );

--- a/src/hooks/useGroupEditForm.ts
+++ b/src/hooks/useGroupEditForm.ts
@@ -2,19 +2,25 @@ import { useState } from "react";
 
 interface UseGroupEditProps {
   initialColor: string;
+  description: string;
 }
 
-function useGroupEditForm({ initialColor }: UseGroupEditProps) {
-  const [formData, setFormData] = useState(initialColor);
+function useGroupEditForm(initialState: UseGroupEditProps) {
+  const [formData, setFormData] = useState(initialState);
 
-  const handleChange = (value: string) => {
-    setFormData(value);
+  const handleChange = (name: keyof UseGroupEditProps) => (value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    console.log(formData);
-  };
+  const handleSubmit =
+    (callback: (data: UseGroupEditProps) => void) =>
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      callback(formData); // formData를 전달해 콜백 실행
+    };
 
   return {
     formData,

--- a/src/hooks/useGroupNewForm.ts
+++ b/src/hooks/useGroupNewForm.ts
@@ -3,6 +3,7 @@ import { useState } from "react";
 interface FormData {
   groupName: string;
   color: string;
+  description: string;
 }
 
 function useGroupNewForm(initialState: FormData) {

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -5,8 +5,8 @@ interface FormData {
   email: string;
   password: string;
   checkPwd: string;
-  profileImage: File | null;
-  profileImagePreview: string | null;
+  // profileImage: File | null;
+  // profileImagePreview: string | null;
 }
 
 function useSignupForm() {
@@ -15,8 +15,8 @@ function useSignupForm() {
     email: "",
     password: "",
     checkPwd: "",
-    profileImage: null,
-    profileImagePreview: null,
+    // profileImage: null,
+    // profileImagePreview: null,
   });
 
   // input onChange 함수
@@ -28,16 +28,16 @@ function useSignupForm() {
   };
 
   // 이미지 미리보기 및 이미지 데이터 (이미지 데이터는 추후 수정 필요)
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]; // e.target은 HTMLInputElement 타입
-    if (file) {
-      setFormData((prev) => ({
-        ...prev,
-        profileImage: file,
-        profileImagePreview: URL.createObjectURL(file), // 미리보기 URL 생성
-      }));
-    }
-  };
+  // const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   const file = e.target.files?.[0]; // e.target은 HTMLInputElement 타입
+  //   if (file) {
+  //     setFormData((prev) => ({
+  //       ...prev,
+  //       profileImage: file,
+  //       profileImagePreview: URL.createObjectURL(file), // 미리보기 URL 생성
+  //     }));
+  //   }
+  // };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -53,7 +53,7 @@ function useSignupForm() {
   return {
     formData,
     handleChange,
-    handleImageChange,
+    // handleImageChange,
     handleSubmit,
   };
 }

--- a/src/pages/group/edit/GroupEditPage.style.ts
+++ b/src/pages/group/edit/GroupEditPage.style.ts
@@ -1,12 +1,16 @@
 import styled from "styled-components";
 
 export const Wrapper = styled.form`
-  max-width: 339px;
+  max-width: 100%;
   width: 100%;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: 50px;
+
+  > button {
+    width: 100%;
+  }
 `;
 
 export const GroupComtainer = styled.div`

--- a/src/pages/group/edit/GroupEditPage.tsx
+++ b/src/pages/group/edit/GroupEditPage.tsx
@@ -2,11 +2,13 @@ import * as Styled from "./GroupEditPage.style";
 import Button from "@/components/common/Button/Button";
 import CircleInput from "@/components/common/Circle/CircleInput";
 import MemberList from "@/components/feature/GroupNewPage/MemberList";
+import TextInput from "@/components/common/TextInput/TextInput";
 import useGroupEditForm from "@/hooks/useGroupEditForm";
 
 interface GroupEditPageProps {
   groupName?: string;
   color?: string;
+  description?: string;
 }
 
 // 수정 페이지에서는 color랑 description 만 변경됨.
@@ -14,21 +16,36 @@ interface GroupEditPageProps {
 function GroupEditPage({
   groupName = "DBDB DEEP",
   color = "#c9c9c9",
+  description = "설명설명~",
 }: GroupEditPageProps) {
   const { formData, handleChange, handleSubmit } = useGroupEditForm({
     initialColor: color,
+    description,
   });
 
+  const onSubmit = (data: typeof formData) => {
+    console.log(data); // 제출된 데이터 처리
+  };
+
   return (
-    <Styled.Wrapper onSubmit={handleSubmit}>
+    <Styled.Wrapper onSubmit={handleSubmit(onSubmit)}>
       <Styled.GroupComtainer>
         <p>그룹명</p>
         <Styled.GroupNameBorder>{groupName}</Styled.GroupNameBorder>
       </Styled.GroupComtainer>
+      <TextInput
+        name="description"
+        type="text"
+        label="그룹 설명"
+        placeholder="그룹 설명을 작성해주세요."
+        required
+        value={formData.description}
+        onChange={handleChange("description")}
+      />
       <MemberList />
       <CircleInput
-        defaultColor={formData}
-        onChange={(value) => handleChange(value)}
+        defaultColor={formData.initialColor}
+        onChange={(value) => handleChange("initialColor")(value)}
       />
       <Button children="저장" buttonType="primaryLarge" type="submit" />
     </Styled.Wrapper>

--- a/src/pages/group/new/GroupNewPage.style.ts
+++ b/src/pages/group/new/GroupNewPage.style.ts
@@ -1,10 +1,13 @@
 import styled from "styled-components";
 
 export const Wrapper = styled.form`
-  width: 339px;
-  padding: 80px 0;
+  width: 100%;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: 50px;
+
+  > button {
+    width: 100%;
+  }
 `;

--- a/src/pages/group/new/GroupNewPage.tsx
+++ b/src/pages/group/new/GroupNewPage.tsx
@@ -1,6 +1,6 @@
 import useGroupNewForm from "@/hooks/useGroupNewForm";
 import * as Styled from "./GroupNewPage.style";
-import MemberList from "@/components/feature/GroupNewPage/MemberList";
+// import MemberList from "@/components/feature/GroupNewPage/MemberList";
 import TextInput from "@/components/common/TextInput/TextInput";
 import CircleInput from "@/components/common/Circle/CircleInput";
 import Button from "@/components/common/Button/Button";
@@ -36,7 +36,7 @@ function GroupNewPage() {
         value={formData.description}
         onChange={handleChange("description")}
       />
-      <MemberList />
+      {/* <MemberList /> */}
       <CircleInput
         defaultColor="#000"
         onChange={(value) => handleChange("color")(value)}

--- a/src/pages/group/new/GroupNewPage.tsx
+++ b/src/pages/group/new/GroupNewPage.tsx
@@ -9,6 +9,7 @@ function GroupNewPage() {
   const { formData, handleChange, handleSubmit } = useGroupNewForm({
     groupName: "",
     color: "",
+    description: "",
   });
 
   const onSubmit = (data: typeof formData) => {
@@ -25,6 +26,15 @@ function GroupNewPage() {
         required
         value={formData.groupName}
         onChange={handleChange("groupName")}
+      />
+      <TextInput
+        name="description"
+        type="text"
+        label="그룹 설명"
+        placeholder="그룹 설명을 작성해주세요."
+        required
+        value={formData.description}
+        onChange={handleChange("description")}
       />
       <MemberList />
       <CircleInput

--- a/src/pages/login/LoginPage.style.ts
+++ b/src/pages/login/LoginPage.style.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const Wrapper = styled.div`
-  max-width: 339px;
+  width: 100%;
   padding-top: 80px;
   display: flex;
   flex-direction: column;
@@ -12,7 +12,6 @@ export const Wrapper = styled.div`
 `;
 
 export const Name = styled.h1`
-  width: 100%;
   color: var(--color-primary);
   display: flex;
   justify-content: flex-start;
@@ -20,7 +19,6 @@ export const Name = styled.h1`
 
 // 소개 멘트
 export const Explan = styled.p`
-  width: 95%;
   display: flex;
   justify-content: flex-start;
 `;

--- a/src/pages/mypage/MyPage.style.ts
+++ b/src/pages/mypage/MyPage.style.ts
@@ -2,11 +2,14 @@ import styled from "styled-components";
 
 export const Wrapper = styled.div`
   width: 100%;
-  height: 100vh;
+  height: 80vh;
+  min-height: 450px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: space-around;
+  justify-content: space-between;
+  position: relative;
+  gap: 30px;
 `;
 
 export const ToggleContainer = styled.div`
@@ -16,8 +19,8 @@ export const ToggleContainer = styled.div`
   align-items: center;
   gap: 13px;
   position: absolute;
-  right: 30px;
-  top: 60px;
+  right: 10px;
+  top: 0px;
 
   > p {
     font-weight: var(--font-weight-bold);

--- a/src/pages/mypage/edit/MyEditPage.style.ts
+++ b/src/pages/mypage/edit/MyEditPage.style.ts
@@ -2,11 +2,11 @@ import styled from "styled-components";
 
 export const Wrapper = styled.div`
   width: 100%;
-  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: space-around;
+  justify-content: space-between;
+  gap: 20px;
 `;
 
 export const Form = styled.form`

--- a/src/pages/mypage/edit/MyEditPage.tsx
+++ b/src/pages/mypage/edit/MyEditPage.tsx
@@ -1,6 +1,6 @@
 import * as Styled from "./MyEditPage.style";
 import { useLocation } from "react-router-dom";
-import Profile from "@/assets/icons/profile.svg?react";
+// import Profile from "@/assets/icons/profile.svg?react";
 import TextInput from "@/components/common/TextInput/TextInput";
 import Button from "@/components/common/Button/Button";
 import useEditPage from "@/hooks/useEditPage";
@@ -10,19 +10,19 @@ function MyEditPage() {
   console.log(location.state); // useNavigate로 가져온 데이터 (닉네임, 사진 데이터가 들어갈 것으로 예상)
 
   const {
-    inputRef,
+    // inputRef,
     formData,
-    handleImageUpload,
+    // handleImageUpload,
     handleInputChange,
     handleSubmit,
-    imagePreview,
+    // imagePreview,
   } = useEditPage();
 
   return (
     <Styled.Wrapper>
       <h1>내 정보 수정</h1>
       <Styled.Form onSubmit={handleSubmit}>
-        <Styled.ImgContainer htmlFor="profileImage">
+        {/* <Styled.ImgContainer htmlFor="profileImage">
           {imagePreview ? (
             <img src={imagePreview} alt="" />
           ) : (
@@ -36,7 +36,7 @@ function MyEditPage() {
           accept="image/*"
           ref={inputRef}
           onChange={handleImageUpload}
-        />
+        /> */}
 
         <TextInput
           name="name"
@@ -49,6 +49,7 @@ function MyEditPage() {
         <TextInput
           name="password"
           label="새 비밀번호"
+          placeholder="새 비밀번호를 입력해주세요"
           type="password"
           value={formData.password}
           onChange={handleInputChange("password")}
@@ -57,6 +58,7 @@ function MyEditPage() {
         <TextInput
           name="checkPwd"
           label="비밀번호 확인"
+          placeholder="새 비밀번호를 확인해주세요"
           type="password"
           value={formData.checkPwd}
           onChange={handleInputChange("checkPwd")}

--- a/src/pages/signup/SignupPage.style.tsx
+++ b/src/pages/signup/SignupPage.style.tsx
@@ -1,20 +1,17 @@
 import styled from "styled-components";
 
 export const Wrapper = styled.div`
-  width: 339px;
+  width: 100%;
   height: 100%;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  gap: 60px;
-  padding-top: 80px;
-  padding-bottom: 20px;
+  gap: 20px;
 `;
 
 export const Form = styled.form`
-  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 30px;

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -2,11 +2,10 @@ import useSignupForm from "@/hooks/useSignupForm";
 import * as Styled from "./SignupPage.style";
 import TextInput from "@/components/common/TextInput/TextInput";
 import Button from "@/components/common/Button/Button";
-import Camera from "@/assets/icons/camera.svg?react";
+// import Camera from "@/assets/icons/camera.svg?react";
 
 function SignupPage() {
-  const { formData, handleChange, handleImageChange, handleSubmit } =
-    useSignupForm();
+  const { formData, handleChange, handleSubmit } = useSignupForm();
 
   return (
     <Styled.Wrapper>
@@ -17,7 +16,7 @@ function SignupPage() {
        ** 그거에 따라 이미지 업로드 보내는 방식이 달라짐 */}
       <Styled.Form onSubmit={handleSubmit}>
         <div>
-          <Styled.Label htmlFor="profileImage">
+          {/* <Styled.Label htmlFor="profileImage">
             <Styled.FilePreview>
               {formData.profileImagePreview ? (
                 <Styled.Img
@@ -33,13 +32,13 @@ function SignupPage() {
                 <Camera width={"3.5rem"} height={"3.5rem"} stroke={"#fff"} />
               )}
             </Styled.FilePreview>
-          </Styled.Label>
-          <Styled.InputFile
+          </Styled.Label> */}
+          {/* <Styled.InputFile
             type="file"
             id="profileImage"
             accept="image/*"
             onChange={handleImageChange}
-          />
+          /> */}
         </div>
 
         <TextInput


### PR DESCRIPTION
## 구현 요약

- 로그인, 회원가입, 마이페이지, 마이페이지 수정 페이지 디자인 css를 수정했습니다.
- 그룹 생성 페이지에 그룹원 추가 부분을 없앴습니다.
- 그룹 수정 페이지에 그룹원 추가 부분을 추가했습니다. 

### 연관 이슈

-  close #112 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
