### PR TITLE
feat: 개인 일정 생성/수정 API 연결

### DIFF
--- a/src/apis/personalSchdule.ts
+++ b/src/apis/personalSchdule.ts
@@ -1,0 +1,33 @@
+import { postRequest, updateRequest } from "@/apis/apiService";
+import {
+  CreatePersonalScheduleRequest,
+  EditPersonalScheduleRequest,
+} from "@/types/apiRequest.type";
+
+// 개인 일정 생성
+export const createPersonalSchedule = async (
+  scheduleData: CreatePersonalScheduleRequest
+) => {
+  try {
+    return await postRequest("/events", scheduleData);
+  } catch (error) {
+    console.error("개인 일정 생성 실패:", error);
+    throw error;
+  }
+};
+
+// 개인 일정 수정
+export const editPersonalSchedule = async ({
+  scheduleId,
+  scheduleData,
+}: {
+  scheduleId: string;
+  scheduleData: EditPersonalScheduleRequest;
+}) => {
+  try {
+    return await updateRequest(`/events/${scheduleId}`, scheduleData);
+  } catch (error) {
+    console.error("개인 일정 수정 실패:", error);
+    throw error;
+  }
+};

--- a/src/components/common/TextInput/TextInput.tsx
+++ b/src/components/common/TextInput/TextInput.tsx
@@ -8,7 +8,7 @@ function TextInput({
   label, // 입력 필드 라벨
   placeholder, // 입력 필드 플레이스홀더
   required = true, // 필수 입력
-  maxLength = 20, // 최대 입력 길이
+  maxLength = 30, // 최대 입력 길이
   minLength = 2, // 최소 입력 길이
   value,
   onChange,

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -4,7 +4,10 @@ import {
   useEditCategory,
   useDeleteCategory,
 } from "./useCategories";
-import { usePersonalSchedules } from "./usePersonalSchedules";
+import {
+  useCreatePersonalSchedule,
+  useEditPersonalSchedule,
+} from "./usePersonalSchedules";
 import { useGroupSchedules } from "./useGroupSchedules";
 import { useCreatePersonalTodo, useEditPersonalTodo } from "./usePersonalTodos";
 import { useGroupTodos } from "./useGroupTodos";
@@ -18,7 +21,8 @@ export {
   useEditCategory,
   useDeleteCategory,
   useGroups,
-  usePersonalSchedules,
+  useCreatePersonalSchedule,
+  useEditPersonalSchedule,
   useCreatePersonalTodo,
   useEditPersonalTodo,
   usePersonalGroupSchedules,

--- a/src/hooks/queries/usePersonalSchedules.ts
+++ b/src/hooks/queries/usePersonalSchedules.ts
@@ -1,10 +1,53 @@
-/**
- * 임시로 더미데이터 사용하고,
- * api 연동시 query 로직이 포함될 예정입니다.
- */
+import {
+  createPersonalSchedule,
+  editPersonalSchedule,
+} from "@/apis/personalSchdule";
+import {
+  CreatePersonalScheduleRequest,
+  EditPersonalScheduleRequest,
+} from "@/types/apiRequest.type";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getYear, getMonth } from "@/utils/date";
 
-import { PERSONAL_EVENT_DATA } from "@/mocks/PERSONAL_EVENT_DATA";
+// 개인 일정 생성 query
+export const useCreatePersonalSchedule = () => {
+  const queryClient = useQueryClient();
 
-export const usePersonalSchedules = () => {
-  return { data: PERSONAL_EVENT_DATA, isLoading: false, error: null };
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: (scheduleData: CreatePersonalScheduleRequest) =>
+      createPersonalSchedule(scheduleData),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["schedules"],
+      });
+    },
+  });
+
+  return { mutate, isPending, error };
+};
+
+// 개인 일정 수정 query
+export const useEditPersonalSchedule = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: ({
+      scheduleId,
+      scheduleData,
+    }: {
+      scheduleId: string;
+      scheduleData: EditPersonalScheduleRequest;
+    }) => editPersonalSchedule({ scheduleId, scheduleData }),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          "schedules",
+          getYear(variables.scheduleData.startDate),
+          getMonth(variables.scheduleData.startDate),
+        ],
+      });
+    },
+  });
+
+  return { mutate, isPending, error };
 };

--- a/src/hooks/queries/usePersonalTodos.ts
+++ b/src/hooks/queries/usePersonalTodos.ts
@@ -4,14 +4,7 @@ import {
   CreatePersonalTodoRequest,
   EditPersonalTodoRequest,
 } from "@/types/apiRequest.type";
-
-const getYear = (date: string) => {
-  return date.split("-")[0];
-};
-
-const getMonth = (date: string) => {
-  return date.split("-")[1];
-};
+import { getYear, getMonth } from "@/utils/date";
 
 // 개인 투두 생성 query
 export const useCreatePersonalTodo = () => {

--- a/src/hooks/useTodoScheduleForm.ts
+++ b/src/hooks/useTodoScheduleForm.ts
@@ -96,12 +96,13 @@ export function useTodoScheduleForm({
   };
 
   const handleToggleUpdate = (type: "time" | "alarm", isOn: boolean) => {
-    handleFormUpdate({
+    setForm((prev) => ({
+      ...prev,
       toggle: {
-        ...form.toggle,
+        ...prev.toggle,
         [type === "time" ? "isTimeOn" : "isAlarmOn"]: isOn,
       },
-    });
+    }));
   };
 
   const handleListUpdate = (updates: {

--- a/src/pages/main/schedule/edit/MainScheduleEditPage.tsx
+++ b/src/pages/main/schedule/edit/MainScheduleEditPage.tsx
@@ -3,6 +3,8 @@ import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
 import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
 import { TodoScheduleFormData } from "@/components/form/TodoScheduleForm/utils";
 import { setTodoScheduleForm } from "@/components/form/TodoScheduleForm/utils";
+import { useEditPersonalSchedule } from "@/hooks/queries/usePersonalSchedules";
+import { formatDateToYYYYMMDD } from "@/utils/date";
 
 function MainScheduleEditPage() {
   const form = useTodoScheduleForm({
@@ -10,28 +12,37 @@ function MainScheduleEditPage() {
     withEndTime: true,
   });
 
+  const { mutate } = useEditPersonalSchedule();
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!form.handleFormValidation()) return;
-    // 스케줄 생성 api
+    // 스케줄 수정 api
+    try {
+      mutate({
+        scheduleId: "64b86382-ac6c-4d0d-9a37-9a11ddc96b79",
+        scheduleData: {
+          personalEventId: "64b86382-ac6c-4d0d-9a37-9a11ddc96b79",
+          title: form.content,
+          startDate: formatDateToYYYYMMDD(form.date.start),
+          endDate: formatDateToYYYYMMDD(form.date.end),
+          startTime: form.toggle.isTimeOn ? form.time.start : null,
+          endTime: form.toggle.isTimeOn ? form.time.end : null,
+          categoryId: form.categoryId || "",
+          isAlarmed: form.toggle.isAlarmOn,
+        },
+      });
+      console.log("스케줄 수정 성공");
+    } catch (error) {
+      console.error(error);
+    }
   };
-
-  useEffect(() => {
-    // 카테고리 목록을 업데이트
-    form.handleListUpdate({
-      categories: [
-        { name: "카테고리1", color: "blue" },
-        { name: "카테고리2", color: "red" },
-        { name: "카테고리3", color: "black" },
-      ],
-    });
-  }, []);
 
   useEffect(() => {
     // 임시 데이터
     const data: TodoScheduleFormData = {
-      content: "투두 내용",
-      category: { name: "카테고리1", color: "blue" },
+      content: "일정 내용",
+      categoryId: "150f63ca-697d-4d3f-b610-304f7a851843",
       startDate: new Date(),
       endDate: new Date(new Date().setDate(new Date().getDate() + 1)),
       startTime: "17:00",

--- a/src/pages/main/schedule/new/MainScheduleNewPage.tsx
+++ b/src/pages/main/schedule/new/MainScheduleNewPage.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
 import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
+import { useCreatePersonalSchedule } from "@/hooks/queries/usePersonalSchedules";
+import { formatDateToYYYYMMDD } from "@/utils/date";
 
 function MainScheduleNewPage() {
   const form = useTodoScheduleForm({
@@ -8,22 +9,27 @@ function MainScheduleNewPage() {
     withEndTime: true,
   });
 
+  const { mutate } = useCreatePersonalSchedule();
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!form.handleFormValidation()) return;
     // 스케줄 생성 api
+    try {
+      mutate({
+        title: form.content,
+        startDate: formatDateToYYYYMMDD(form.date.start),
+        endDate: formatDateToYYYYMMDD(form.date.end),
+        startTime: form.toggle.isTimeOn ? form.time.start : null,
+        endTime: form.toggle.isTimeOn ? form.time.end : null,
+        categoryId: form.categoryId || "",
+        isAlarmed: form.toggle.isAlarmOn,
+      });
+      console.log("스케줄 생성 성공");
+    } catch (error) {
+      console.error(error);
+    }
   };
-
-  useEffect(() => {
-    // 카테고리 목록을 업데이트
-    form.handleListUpdate({
-      categories: [
-        { name: "카테고리1", color: "blue" },
-        { name: "카테고리2", color: "red" },
-        { name: "카테고리3", color: "black" },
-      ],
-    });
-  }, []);
 
   return (
     <TodoScheduleForm

--- a/src/pages/main/todo/edit/MainTodoEditPage.tsx
+++ b/src/pages/main/todo/edit/MainTodoEditPage.tsx
@@ -17,7 +17,7 @@ function MainTodoEditPage() {
     // Todo 수정 api
     try {
       mutate({
-        todoId: "4be521bd-6e48-45c1-8b88-ed8f2812cfa8",
+        todoId: "29625a03-6e46-438c-86c9-fbebe5d60e51",
         todoData: {
           title: form.content,
           date: formatDateToYYYYMMDD(form.date.start),
@@ -34,7 +34,7 @@ function MainTodoEditPage() {
   useEffect(() => {
     const data: TodoScheduleFormData = {
       content: "투두 내용",
-      categoryId: "ed4a6d46-98e8-48db-8d4c-b229c66528af",
+      categoryId: "150f63ca-697d-4d3f-b610-304f7a851843",
       startDate: new Date(),
       startTime: "17:00",
       isTimeOn: true,

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -15,7 +15,6 @@ function SignupPage() {
        ** 그 전에는 경로만 보낸다고 했었음
        ** 그거에 따라 이미지 업로드 보내는 방식이 달라짐 */}
       <Styled.Form onSubmit={handleSubmit}>
-
         {/* <div>
           <Styled.Label htmlFor="profileImage">
 
@@ -35,15 +34,13 @@ function SignupPage() {
               )}
             </Styled.FilePreview>
           </Styled.Label> */}
-          {/* <Styled.InputFile
+        {/* <Styled.InputFile
             type="file"
             id="profileImage"
             accept="image/*"
             onChange={handleImageChange}
           />
         </div> */}
-
-
 
         <TextInput
           name="email"
@@ -73,8 +70,8 @@ function SignupPage() {
           label="비밀번호 확인"
           placeholder="비밀번호를 확인해주세요"
           required
-          maxLength={10}
-          minLength={5}
+          maxLength={16}
+          minLength={8}
           value={formData.checkPwd}
           onChange={handleChange("checkPwd")}
         />

--- a/src/types/apiRequest.type.ts
+++ b/src/types/apiRequest.type.ts
@@ -26,3 +26,26 @@ export interface EditPersonalTodoRequest {
   startTime: string | null;
   categoryId: string;
 }
+
+// 개인 일정 생성
+export interface CreatePersonalScheduleRequest {
+  title: string;
+  startDate: string;
+  endDate: string;
+  startTime: string | null;
+  endTime: string | null;
+  isAlarmed: boolean;
+  categoryId: string;
+}
+
+// 개인 일정 수정
+export interface EditPersonalScheduleRequest {
+  personalEventId: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  startTime: string | null;
+  endTime: string | null;
+  isAlarmed: boolean;
+  categoryId: string;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -5,3 +5,11 @@ export const formatDateToYYYYMMDD = (date: Date): string => {
 
   return `${year}-${month}-${day}`;
 };
+
+export const getYear = (date: string) => {
+  return date.split("-")[0];
+};
+
+export const getMonth = (date: string) => {
+  return date.split("-")[1];
+};


### PR DESCRIPTION
## 구현 요약

- 개인 일정 생성/수정 API 연결
- 개인 일정 생성/수정 관련 훅 제작
- 개인 일정 생성/수정 관련 타입 정의
- 시간유무, 알림유무 토글 함수 에러 수정
- 로그인, 회원가입 input의 maxLength 변경

### 연관 이슈

- close #126   

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
