### PR TITLE
feat: 그룹 페이지 api 연동

### DIFF
--- a/src/apis/apiService.ts
+++ b/src/apis/apiService.ts
@@ -24,6 +24,50 @@ apiClient.interceptors.request.use(
   }
 );
 
+// 토큰 재발급, 오류로 인해 주석처리
+// apiClient.interceptors.response.use(
+//   (response) => {
+//     // 응답이 성공적이면 그대로 반환
+//     return response;
+//   },
+//   async (error) => {
+//     const originalRequest = error.config;
+
+//     // 401 오류이고, 재시도 중이 아닌 경우
+//     if (
+//       error.response?.status === 401 &&
+//       !originalRequest._retry // _retry 플래그를 사용하여 무한 루프 방지
+//     ) {
+//       originalRequest._retry = true;
+
+//       try {
+//         // Refresh 토큰을 사용하여 새 액세스 토큰 요청
+//         const { data } = await postRequest(`/user/reissue`, {});
+
+//         alert("리프레시 토큰을 통해 액세스 토큰 재발급 확인!");
+//         console.log(data); // 토큰값 확인
+//         // 새로운 액세스 토큰 저장
+//         useAuthStore.getState().setAccessToken(data.access_token);
+
+//         // 원래 요청에 새 토큰 추가
+//         originalRequest.headers.Authorization =
+//           useAuthStore.getState().access_token;
+
+//         // 원래 요청 재시도
+//         // return apiClient(originalRequest);
+//       } catch (refreshError) {
+//         // Refresh 실패 시 로그아웃 처리
+//         useAuthStore.getState().logout(); // 로그아웃 처리
+//         console.log("로그아웃 처리 ");
+//         return Promise.reject(refreshError);
+//       }
+//     }
+
+//     // 그 외의 에러는 그대로 반환
+//     // return Promise.reject(error);
+//   }
+// );
+
 // GET 요청 함수
 export const getRequest = async (url: string, params?: object) => {
   try {

--- a/src/apis/group/deleteMember.ts
+++ b/src/apis/group/deleteMember.ts
@@ -1,0 +1,13 @@
+import { deleteRequest } from "../apiService";
+
+// 그룹 조회
+export const deleteMember = async (groupSettingId: string) => {
+  try {
+    const res = await deleteRequest(
+      `/groups-setting/${groupSettingId}/ejection`
+    );
+    return res;
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/apis/group/getGroup.ts
+++ b/src/apis/group/getGroup.ts
@@ -1,0 +1,11 @@
+import { getRequest } from "../apiService";
+
+// 그룹 조회
+export const getGroup = async () => {
+  try {
+    const res = await getRequest("/groups");
+    return res;
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/apis/group/getMember.ts
+++ b/src/apis/group/getMember.ts
@@ -1,0 +1,15 @@
+import { getRequest } from "../apiService";
+
+interface UserRequestParams {
+  group_id: string;
+}
+
+// 특정 그룹 멤버 조회
+export const getMember = async ({ group_id }: UserRequestParams) => {
+  try {
+    const res = await getRequest(`/groups-setting/${group_id}`);
+    return res;
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/apis/group/postGroup.ts
+++ b/src/apis/group/postGroup.ts
@@ -5,7 +5,7 @@ interface UserRequestParams {
   description: string;
   groupColor: string;
 }
-
+// 그룹 생성
 export const postGroup = async (userForm: UserRequestParams) => {
   try {
     const res = await postRequest("/groups", userForm);

--- a/src/apis/group/postGroup.ts
+++ b/src/apis/group/postGroup.ts
@@ -1,0 +1,16 @@
+import { postRequest } from "../apiService";
+
+interface UserRequestParams {
+  groupName: string;
+  description: string;
+  groupColor: string;
+}
+
+export const postGroup = async (userForm: UserRequestParams) => {
+  try {
+    const res = await postRequest("/groups", userForm);
+    return res;
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/apis/group/postInvitation.ts
+++ b/src/apis/group/postInvitation.ts
@@ -1,0 +1,20 @@
+import { postRequest } from "../apiService";
+
+interface UserRequestParams {
+  group_id: string;
+  nickname: string;
+}
+// 그룹 생성
+export const postInvitation = async ({
+  group_id,
+  nickname,
+}: UserRequestParams) => {
+  try {
+    const res = await postRequest(`/groups-invitation/${group_id}`, {
+      nickname,
+    });
+    return res;
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/apis/group/putGroup.ts
+++ b/src/apis/group/putGroup.ts
@@ -1,0 +1,24 @@
+import { updateRequest } from "../apiService";
+
+interface FormDataProps {
+  formData: {
+    groupId: string;
+    groupName: string;
+    description: string;
+    initialColor: string;
+  };
+}
+
+// 그룹 조회
+export const putGroup = async ({ formData }: FormDataProps) => {
+  try {
+    const res = await updateRequest(`/groups/${formData.groupId}`, {
+      name: formData.groupName,
+      description: formData.description,
+      color: formData.initialColor,
+    });
+    return res;
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/components/feature/GroupNewPage/MemberList.tsx
+++ b/src/components/feature/GroupNewPage/MemberList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import * as Styled from "./MemberList.style";
 // import Plus from "@/assets/icons/plus.svg?react";
 import Profile from "@/assets/icons/profile.svg?react";
@@ -6,23 +6,50 @@ import Trashcan from "@/assets/icons/trashcan.svg?react";
 import TextInput from "@/components/common/TextInput/TextInput";
 import Button from "@/components/common/Button/Button";
 import { toast } from "react-toastify";
+import { postInvitation } from "@/apis/group/postInvitation";
+import { getMember } from "@/apis/group/getMember";
 
-// css 해야됨.
+interface UserData {
+  groupSettingId: string;
+  userId: string;
+  nickname: string;
+  role: string;
+}
+
 function MemberList() {
+  // 테스트용 group_id, 나중엔 props 또는 useLocation을 사용하지 않을까 싶습니다.
+  const groupId = "a85e5db7-593f-429a-bc80-385408f0b934";
   const [nickname, setNickname] = useState("");
-  const [memberList, setMemberList] = useState<string[]>([]);
+  const [memberList, setMemberList] = useState<UserData[]>([]);
 
   const handleChange = (value: string) => {
     setNickname(value);
-    console.log(value);
   };
 
-  const handleSubmit = () => {
-    console.log(nickname); // 닉네임 출력
-    toast.success(`${nickname}에게 초대 메세지를 보냈습니다!`);
-    setNickname(""); // 닉네임 초기화
-    setMemberList((prev) => [...prev, nickname]);
+  const handleSubmit = async () => {
+    const res = await postInvitation({
+      // group_id 는 임시값 수정 필요
+      group_id: groupId,
+      nickname,
+    });
+    console.log(res);
+    if (res.code == 201) {
+      toast.success(`${nickname}에게 초대 메세지를 보냈습니다.`);
+      setNickname("");
+    } else {
+      toast.error(`${res.response.data.message}`);
+    }
   };
+
+  useEffect(() => {
+    // 이 그룹에 속해있는 그룹원을 조회 및 렌더링에 반영
+    getMember({ group_id: groupId })
+      .then((res) => {
+        console.log(res);
+        setMemberList(res.data);
+      })
+      .catch((err) => console.log(err));
+  }, []);
 
   return (
     <Styled.Wrapper>
@@ -35,7 +62,7 @@ function MemberList() {
           type="text"
           label="팀원 추가"
           placeholder="팀원의 닉네임을 입력하고 한 번에 한 명씩 초대해주세요."
-          required
+          required={false}
           value={nickname}
           onChange={handleChange}
         />
@@ -54,11 +81,12 @@ function MemberList() {
        */}
       <p>팀원 목록</p>
       <Styled.UserWrapper>
-        {memberList.map((name) => (
-          <Styled.UserInfoContainer>
+        {memberList.map((user) => (
+          <Styled.UserInfoContainer key={user.nickname}>
             <Styled.UserInfo>
               <Profile width={25} height={25} stroke="#97CDBD" fill="#97CDBD" />
-              <p>{name}</p>
+              <p>{user.nickname}</p>
+              <p>{user.role}</p>
             </Styled.UserInfo>
             <Trashcan
               width={16}

--- a/src/components/feature/GroupNewPage/MemberList.tsx
+++ b/src/components/feature/GroupNewPage/MemberList.tsx
@@ -8,6 +8,7 @@ import Button from "@/components/common/Button/Button";
 import { toast } from "react-toastify";
 import { postInvitation } from "@/apis/group/postInvitation";
 import { getMember } from "@/apis/group/getMember";
+import { deleteMember } from "@/apis/group/deleteMember";
 
 interface UserData {
   groupSettingId: string;
@@ -38,6 +39,20 @@ function MemberList() {
       setNickname("");
     } else {
       toast.error(`${res.response.data.message}`);
+    }
+  };
+
+  const handleEjection = async (groupSettingId: string) => {
+    // 그룹원 방출(그룹장)
+    const res = await deleteMember(groupSettingId);
+    if (res.code === 200) {
+      toast(res.message);
+      // 삭제된 멤버를 제외하고 상태를 업데이트
+      setMemberList((prevList) =>
+        prevList.filter((user) => user.groupSettingId !== groupSettingId)
+      );
+    } else if (res.code === 404 || res.code === 401) {
+      toast.error(res.message);
     }
   };
 
@@ -93,6 +108,7 @@ function MemberList() {
               height={16}
               stroke="#B1B1B1"
               cursor="pointer"
+              onClick={() => handleEjection(user.groupSettingId)}
             />
           </Styled.UserInfoContainer>
         ))}

--- a/src/hooks/useGroupEditForm.ts
+++ b/src/hooks/useGroupEditForm.ts
@@ -15,12 +15,10 @@ function useGroupEditForm(initialState: UseGroupEditProps) {
     }));
   };
 
-  const handleSubmit =
-    (callback: (data: UseGroupEditProps) => void) =>
-    (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      callback(formData); // formData를 전달해 콜백 실행
-    };
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log(formData);
+  };
 
   return {
     formData,

--- a/src/hooks/useGroupEditForm.ts
+++ b/src/hooks/useGroupEditForm.ts
@@ -1,11 +1,17 @@
 import { useState } from "react";
+import { putGroup } from "@/apis/group/putGroup";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 
 interface UseGroupEditProps {
+  groupName: string;
   initialColor: string;
   description: string;
+  groupId: string;
 }
 
 function useGroupEditForm(initialState: UseGroupEditProps) {
+  const navigate = useNavigate();
   const [formData, setFormData] = useState(initialState);
 
   const handleChange = (name: keyof UseGroupEditProps) => (value: string) => {
@@ -15,9 +21,15 @@ function useGroupEditForm(initialState: UseGroupEditProps) {
     }));
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(formData);
+    const res = await putGroup({ formData });
+    if (res.code == 200) {
+      // 토스트 메세지를 띄우지 않는 이유는 navigate시 변경되어 있기 때문
+      navigate("/group/1");
+    } else {
+      toast.error("잠시후 다시 시도해주세요.");
+    }
   };
 
   return {

--- a/src/hooks/useGroupNewForm.ts
+++ b/src/hooks/useGroupNewForm.ts
@@ -1,4 +1,7 @@
 import { useState } from "react";
+import { postGroup } from "@/apis/group/postGroup";
+import { toast } from "react-toastify";
+import { useNavigate } from "react-router-dom";
 
 interface FormData {
   groupName: string;
@@ -7,6 +10,7 @@ interface FormData {
 }
 
 function useGroupNewForm(initialState: FormData) {
+  const navigate = useNavigate();
   const [formData, setFormData] = useState<FormData>(initialState);
 
   const handleChange = (name: keyof FormData) => (value: string) => {
@@ -16,12 +20,22 @@ function useGroupNewForm(initialState: FormData) {
     }));
   };
 
-  const handleSubmit =
-    (callback: (data: FormData) => void) =>
-    (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      callback(formData); // formData를 전달해 콜백 실행
-    };
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const res = await postGroup({
+      groupName: formData.groupName,
+      description: formData.description,
+      groupColor: formData.color,
+    });
+
+    console.log(res);
+    if (res.code == 201) {
+      toast(res.message);
+      navigate("/group/1"); // 생성 후 그룹 페이지 1로 이동
+    } else {
+      toast("그룹 생성에 실패했습니다.");
+    }
+  };
 
   return {
     formData,

--- a/src/hooks/useInviteMember.ts
+++ b/src/hooks/useInviteMember.ts
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { toast } from "react-toastify";
+import { postInvitation } from "@/apis/group/postInvitation";
+
+export const useInviteMember = (
+  groupId: string,
+  refreshMemberList: () => void
+) => {
+  const [nickname, setNickname] = useState("");
+
+  const handleChange = (value: string) => {
+    setNickname(value);
+  };
+
+  const handleSubmit = () => {
+    if (!nickname.trim()) {
+      toast.error("닉네임을 입력해주세요.");
+      return;
+    }
+
+    postInvitation({
+      group_id: groupId,
+      nickname,
+    })
+      .then(() => {
+        toast.success(`${nickname}에게 초대 메세지를 보냈습니다!`);
+        setNickname(""); // 닉네임 초기화
+        refreshMemberList(); // 멤버 목록 새로고침
+      })
+      .catch((err) => {
+        toast.error(err.message);
+      });
+  };
+
+  return { nickname, handleChange, handleSubmit };
+};

--- a/src/hooks/useMemberList.ts
+++ b/src/hooks/useMemberList.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+import { getMember } from "@/apis/group/getMember";
+
+interface Member {
+  nickname: string;
+  role: string;
+}
+
+export const useMemberList = (groupId: string) => {
+  const [memberList, setMemberList] = useState<Member[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getMember({ group_id: groupId })
+      .then((res) => {
+        setMemberList(res.data);
+      })
+      .catch((err) => {
+        console.error(err);
+        setError(err.message);
+      });
+  }, [groupId]);
+
+  return { memberList, setMemberList, error };
+};

--- a/src/pages/group/edit/GroupEditPage.tsx
+++ b/src/pages/group/edit/GroupEditPage.tsx
@@ -23,12 +23,8 @@ function GroupEditPage({
     description,
   });
 
-  const onSubmit = (data: typeof formData) => {
-    console.log(data); // 제출된 데이터 처리
-  };
-
   return (
-    <Styled.Wrapper onSubmit={handleSubmit(onSubmit)}>
+    <Styled.Wrapper onSubmit={handleSubmit}>
       <Styled.GroupComtainer>
         <p>그룹명</p>
         <Styled.GroupNameBorder>{groupName}</Styled.GroupNameBorder>

--- a/src/pages/group/edit/GroupEditPage.tsx
+++ b/src/pages/group/edit/GroupEditPage.tsx
@@ -13,22 +13,32 @@ interface GroupEditPageProps {
 
 // 수정 페이지에서는 color랑 description 만 변경됨.
 // 데이터를 props를 통해 받게 되어있는데, useParam or useLocation에 맞춰 추후 수정 필요
+
+// **가장 중요** -> 그룹 수정 api 연동해야 함
 function GroupEditPage({
   groupName = "DBDB DEEP",
   color = "#c9c9c9",
   description = "설명설명~",
 }: GroupEditPageProps) {
   const { formData, handleChange, handleSubmit } = useGroupEditForm({
+    groupName,
     initialColor: color,
     description,
+    groupId: "a85e5db7-593f-429a-bc80-385408f0b934",
   });
 
   return (
     <Styled.Wrapper onSubmit={handleSubmit}>
-      <Styled.GroupComtainer>
-        <p>그룹명</p>
-        <Styled.GroupNameBorder>{groupName}</Styled.GroupNameBorder>
-      </Styled.GroupComtainer>
+      <TextInput
+        name="groupName"
+        type="text"
+        label="그룹명"
+        placeholder="그룹명을 작성해주세요."
+        required
+        value={formData.groupName}
+        onChange={handleChange("groupName")}
+      />
+
       <TextInput
         name="description"
         type="text"

--- a/src/pages/group/new/GroupNewPage.tsx
+++ b/src/pages/group/new/GroupNewPage.tsx
@@ -12,12 +12,8 @@ function GroupNewPage() {
     description: "",
   });
 
-  const onSubmit = (data: typeof formData) => {
-    console.log(data); // 제출된 데이터 처리
-  };
-
   return (
-    <Styled.Wrapper onSubmit={handleSubmit(onSubmit)}>
+    <Styled.Wrapper onSubmit={handleSubmit}>
       <TextInput
         name="groupName"
         type="text"

--- a/src/pages/group/noData/GroupNoData.tsx
+++ b/src/pages/group/noData/GroupNoData.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import * as Styled from "./GroupNoData.style";
 import Button from "@/components/common/Button/Button";
+import { getGroup } from "@/apis/group/getGroup";
 
 function GroupNoData() {
   const navigate = useNavigate();
@@ -9,10 +10,13 @@ function GroupNoData() {
   useEffect(() => {
     // 여기서 사용자의 그룹이 있는지 확인 (그룹 조회 api)
     // 그룹이 있다면 ->그룹 페이지로 렌더링
-    // if () {
-    // navigate("/group/1");
-    // }
-    // 그룹이 없다면 -> 현재 페이지 렌더링
+    getGroup()
+      .then((res) => {
+        console.log(res);
+        // /group/1 이 경로로 그룹 캘린더가 생길지도 모르겠음
+        // navigate("/group/1");
+      })
+      .catch((err) => console.log(err));
   }, []);
   return (
     <Styled.Wrapper>

--- a/src/pages/group/noData/GroupNoData.tsx
+++ b/src/pages/group/noData/GroupNoData.tsx
@@ -14,7 +14,7 @@ function GroupNoData() {
       .then((res) => {
         console.log(res);
         // /group/1 이 경로로 그룹 캘린더가 생길지도 모르겠음
-        // navigate("/group/1");
+        navigate("/group/1");
       })
       .catch((err) => console.log(err));
   }, []);

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -2,8 +2,9 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 interface UserState {
-  access_token: string;
+  access_token: string | null;
   setAccessToken: (accToken: string) => void;
+  logout: () => void;
 }
 
 const useAuthStore = create(
@@ -11,6 +12,10 @@ const useAuthStore = create(
     (set) => ({
       access_token: "",
       setAccessToken: (accToken) => set({ access_token: accToken }),
+      logout: () => {
+        set({ access_token: null });
+        window.location.href = "/login";
+      },
     }),
     {
       name: "userTokenStorage",


### PR DESCRIPTION
## 구현 요약

groupId와 수정시 필요한 기본 값들은 정적으로 작성해두고 api 연동했습니다.

- 그룹 생성 페이지
  - 그룹 생성 
- 그룹 수정 페이지
  - 그룹 수정
  - 그룹원 조회
  - 그룹원 삭제(그룹장)
  - 그룹원 초대

- 그룹이 없을 때 렌더링 되는 페이지
  - 그룹 조회 (그룹이 있으면 그룹 캘린더로 이동 시켰습니다.)

### 연관 이슈

- close #128 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
