### PR TITLE
feat: 개인 투두&일정의 생성&수정 페이지 다른 페이지와 연결

### DIFF
--- a/src/components/feature/main/TodoItem/TodoItem.tsx
+++ b/src/components/feature/main/TodoItem/TodoItem.tsx
@@ -22,7 +22,7 @@ function TodoItem({ todo }: TodoItemProps) {
   const { mutate: changeGroupTodoState } = useChangePersonalGroupTodoState();
 
   const handleEditClick = () => {
-    navigate(`/main/todo/${todo.id}/edit`);
+    navigate(`/main/todo/${todo.id}/edit`, { state: { todo } });
   };
 
   const handleDeleteClick = () => {

--- a/src/components/form/TodoScheduleForm/utils.ts
+++ b/src/components/form/TodoScheduleForm/utils.ts
@@ -1,6 +1,8 @@
 import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
 
 export interface TodoScheduleFormData {
+  todoId?: string;
+  scheduleId?: string;
   content?: string;
   groupId?: string;
   categoryId?: string | null;
@@ -17,6 +19,8 @@ export function setTodoScheduleForm(
   form: ReturnType<typeof useTodoScheduleForm>,
   data: TodoScheduleFormData
 ) {
+  if (data.todoId) form.handleTodoIdUpdate(data.todoId);
+  if (data.scheduleId) form.handleScheduleIdUpdate(data.scheduleId);
   if (data.content) form.handleContentUpdate(data.content);
   if (data.groupId) form.handleGroupIdUpdate(data.groupId);
   if (data.categoryId) form.handleCategoryUpdate(data.categoryId);

--- a/src/hooks/useTodoScheduleForm.ts
+++ b/src/hooks/useTodoScheduleForm.ts
@@ -3,6 +3,8 @@ import { GroupMember, OptionType } from "@/types/select.types";
 import { useToast } from "@/hooks/useToast";
 
 interface TodoScheduleFormState {
+  todoId?: string; // 투두 id
+  scheduleId?: string; // 스케줄 id
   content: string; // 내용
   categoryId: string | null; // 카테고리
   groupId: string; // 그룹 id
@@ -38,6 +40,8 @@ export function useTodoScheduleForm({
 }: useTodoScheduleFormProps = {}) {
   // 폼의 초기 상태 설정
   const [form, setForm] = useState<TodoScheduleFormState>({
+    todoId: "",
+    scheduleId: "",
     content: "",
     categoryId: null,
     groupId: "",
@@ -65,6 +69,14 @@ export function useTodoScheduleForm({
   // 폼 전체 업데이트 함수
   const handleFormUpdate = (updates: Partial<TodoScheduleFormState>) => {
     setForm((prev) => ({ ...prev, ...updates }));
+  };
+
+  const handleTodoIdUpdate = (value: string) => {
+    handleFormUpdate({ todoId: value });
+  };
+
+  const handleScheduleIdUpdate = (value: string) => {
+    handleFormUpdate({ scheduleId: value });
   };
 
   const handleContentUpdate = (value: string) => {
@@ -102,12 +114,13 @@ export function useTodoScheduleForm({
   };
 
   const handleToggleUpdate = (type: "time" | "alarm", isOn: boolean) => {
-    handleFormUpdate({
+    setForm((prev) => ({
+      ...prev,
       toggle: {
-        ...form.toggle,
+        ...prev.toggle,
         [type === "time" ? "isTimeOn" : "isAlarmOn"]: isOn,
       },
-    });
+    }));
   };
 
   const handleListUpdate = (updates: {
@@ -152,6 +165,8 @@ export function useTodoScheduleForm({
   // 폼 상태와 핸들러 함수들을 반환
   return {
     ...form,
+    handleTodoIdUpdate,
+    handleScheduleIdUpdate,
     handleFormUpdate,
     handleContentUpdate,
     handleGroupIdUpdate,

--- a/src/pages/main/schedule/new/MainScheduleNewPage.tsx
+++ b/src/pages/main/schedule/new/MainScheduleNewPage.tsx
@@ -2,8 +2,10 @@ import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
 import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
 import { useCreatePersonalSchedule } from "@/hooks/queries/usePersonalSchedules";
 import { formatDateToYYYYMMDD } from "@/utils/date";
-
+import { useNavigate } from "react-router-dom";
 function MainScheduleNewPage() {
+  const navigate = useNavigate();
+
   const form = useTodoScheduleForm({
     withEndDate: true,
     withEndTime: true,
@@ -15,8 +17,8 @@ function MainScheduleNewPage() {
     e.preventDefault();
     if (!form.handleFormValidation()) return;
     // 스케줄 생성 api
-    try {
-      mutate({
+    mutate(
+      {
         title: form.content,
         startDate: formatDateToYYYYMMDD(form.date.start),
         endDate: formatDateToYYYYMMDD(form.date.end),
@@ -24,11 +26,17 @@ function MainScheduleNewPage() {
         endTime: form.toggle.isTimeOn ? form.time.end : null,
         categoryId: form.categoryId || "",
         isAlarmed: form.toggle.isAlarmOn,
-      });
-      console.log("스케줄 생성 성공");
-    } catch (error) {
-      console.error(error);
-    }
+      },
+      {
+        onSuccess: () => {
+          console.log("일정 생성 성공");
+          navigate(-1);
+        },
+        onError: (error) => {
+          console.error("일정 생성 실패:", error);
+        },
+      }
+    );
   };
 
   return (

--- a/src/pages/main/todo/edit/MainTodoEditPage.tsx
+++ b/src/pages/main/todo/edit/MainTodoEditPage.tsx
@@ -5,8 +5,13 @@ import { TodoScheduleFormData } from "@/components/form/TodoScheduleForm/utils";
 import { setTodoScheduleForm } from "@/components/form/TodoScheduleForm/utils";
 import { useEditPersonalTodo } from "@/hooks/queries/usePersonalTodos";
 import { formatDateToYYYYMMDD } from "@/utils/date";
+import { useLocation, useNavigate } from "react-router-dom";
+import { MainTodo } from "@/models/MainTodo";
 
 function MainTodoEditPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const form = useTodoScheduleForm();
 
   const { mutate } = useEditPersonalTodo();
@@ -15,29 +20,37 @@ function MainTodoEditPage() {
     e.preventDefault();
     if (!form.handleFormValidation()) return;
     // Todo 수정 api
-    try {
-      mutate({
-        todoId: "29625a03-6e46-438c-86c9-fbebe5d60e51",
+    mutate(
+      {
+        todoId: form.todoId || "",
         todoData: {
           title: form.content,
           date: formatDateToYYYYMMDD(form.date.start),
           startTime: form.toggle.isTimeOn ? form.time.start : null,
           categoryId: form.categoryId || "",
         },
-      });
-      console.log("투두 수정 성공");
-    } catch (error) {
-      console.error(error);
-    }
+      },
+      {
+        onSuccess: () => {
+          console.log("투두 수정 성공");
+          navigate(-1);
+        },
+        onError: (error) => {
+          console.error("투두 수정 실패:", error);
+        },
+      }
+    );
   };
 
   useEffect(() => {
+    const todo: MainTodo = location.state?.todo;
     const data: TodoScheduleFormData = {
-      content: "투두 내용",
-      categoryId: "150f63ca-697d-4d3f-b610-304f7a851843",
-      startDate: new Date(),
-      startTime: "17:00",
-      isTimeOn: true,
+      todoId: todo.id,
+      content: todo.title,
+      categoryId: todo.categoryId,
+      startDate: new Date(todo.date),
+      startTime: todo.startTime || "",
+      isTimeOn: !!todo.startTime,
     };
     setTodoScheduleForm(form, data);
   }, []);

--- a/src/pages/main/todo/new/MainTodoNewPage.tsx
+++ b/src/pages/main/todo/new/MainTodoNewPage.tsx
@@ -2,8 +2,10 @@ import { useTodoScheduleForm } from "@/hooks/useTodoScheduleForm";
 import TodoScheduleForm from "@/components/form/TodoScheduleForm/TodoScheduleForm";
 import { formatDateToYYYYMMDD } from "@/utils/date";
 import { useCreatePersonalTodo } from "@/hooks/queries/usePersonalTodos";
+import { useNavigate } from "react-router-dom";
 
 function MainTodoNewPage() {
+  const navigate = useNavigate();
   const form = useTodoScheduleForm();
 
   const { mutate } = useCreatePersonalTodo();
@@ -12,17 +14,23 @@ function MainTodoNewPage() {
     e.preventDefault();
     if (!form.handleFormValidation()) return;
     // Todo 생성 api
-    try {
-      mutate({
+    mutate(
+      {
         title: form.content,
         date: formatDateToYYYYMMDD(form.date.start),
         startTime: form.toggle.isTimeOn ? form.time.start : null,
         categoryId: form.categoryId || "",
-      });
-      console.log("투두 생성 성공");
-    } catch (error) {
-      console.error(error);
-    }
+      },
+      {
+        onSuccess: () => {
+          console.log("투두 생성 성공");
+          navigate(-1);
+        },
+        onError: (error) => {
+          console.error("투두 생성 실패:", error);
+        },
+      }
+    );
   };
 
   return (


### PR DESCRIPTION
## 구현 요약

- 개인 투두 생성 페이지 다른 페이지와 연결
- 개인 투두 수정 페이지 다른 페이지와 연결
- 개인 일정 생성 페이지 다른 페이지와 연결
- 개인 일정 수정 페이지 다른 페이지와 연결

### 연관 이슈

- close #143 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
