### PR TITLE
feat: 카테고리 api 연결 및 수정

### DIFF
--- a/src/apis/categories.ts
+++ b/src/apis/categories.ts
@@ -32,7 +32,10 @@ export const createCategory = async (categoryData: CreateCategoryRequest) => {
 // 카테고리 수정
 export const editCategory = async (categoryData: EditCategoryRequest) => {
   try {
-    return await updateRequest("/categories", categoryData);
+    return await updateRequest(
+      `/categories/${categoryData.categoryId} `,
+      categoryData
+    );
   } catch (error) {
     console.error("카테고리 수정 실패:", error);
     throw error;

--- a/src/components/common/SelectList/Category/CategorySelect.tsx
+++ b/src/components/common/SelectList/Category/CategorySelect.tsx
@@ -2,7 +2,7 @@ import Select, { SingleValue } from "react-select";
 import * as Style from "./CategorySelect.style";
 import Circle from "../../Circle/Circle";
 import { OptionType, CategoryProps } from "@/types/select.types";
-import { useGetCategories } from "@/hooks/queries";
+import { useGetPersonalCategories } from "@/hooks/queries";
 import { Category } from "@/types/category.type";
 
 const CategoryValue = (props: { data: OptionType }) => {
@@ -35,7 +35,7 @@ function CategorySelect({
   onCategoryChange,
   menuPlacement = "bottom", // 기본값: 아래로 출력
 }: CategoryProps & { menuPlacement?: "top" | "bottom" }) {
-  const { data, isLoading } = useGetCategories();
+  const { data, isLoading } = useGetPersonalCategories();
   const category = data?.data.find(
     (category: Category) => category.categoryId === categoryId
   );

--- a/src/components/feature/CategoryList/CategoryList.tsx
+++ b/src/components/feature/CategoryList/CategoryList.tsx
@@ -2,15 +2,14 @@ import Circle from "@/components/common/Circle/Circle";
 import * as Styled from "./CategoryList.style";
 import { useNavigate } from "react-router-dom";
 import EditDeleteIcon from "../EditDeleteIcon/EditDeleteIcon";
+import { Category } from "@/types";
+import { useDeleteCategory } from "@/hooks/queries/useCategories";
+import { useToast } from "@/hooks/useToast";
 
-interface CategoryListProps {
-  categoryId: number;
-  color: string;
-  name: string;
-}
-
-function CategoryList({ categoryId, color, name }: CategoryListProps) {
+function CategoryList({ categoryId, color, name }: Category) {
   const navigate = useNavigate();
+  const { mutate: deleteCategory } = useDeleteCategory();
+  const { showToast } = useToast();
 
   // 수정 버튼 클릭
   const handleEditClick = () => {
@@ -21,8 +20,14 @@ function CategoryList({ categoryId, color, name }: CategoryListProps) {
 
   // 삭제 버튼 클릭
   const handleDeleteClick = () => {
-    console.log(categoryId);
-    // 실제 삭제 로직 추가
+    deleteCategory(categoryId, {
+      onSuccess: () => {
+        showToast("카테고리가 삭제되었습니다.", "success");
+      },
+      onError: () => {
+        showToast("카테고리 삭제에 실패했습니다.", "error");
+      },
+    });
   };
 
   return (

--- a/src/components/feature/CatergoryForm/CategoryForm.style.ts
+++ b/src/components/feature/CatergoryForm/CategoryForm.style.ts
@@ -4,7 +4,7 @@ export const Container = styled.form`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100vh;
+  height: 80vh;
   box-sizing: border-box;
 `;
 

--- a/src/components/feature/CatergoryForm/CategoryForm.tsx
+++ b/src/components/feature/CatergoryForm/CategoryForm.tsx
@@ -4,7 +4,7 @@ import Button from "@/components/common/Button/Button";
 import * as Styled from "./CategoryForm.style";
 
 interface CategoryFormProps {
-  formData: { categoryName: string; categoryColor: string };
+  formData: { name: string; color: string };
   onTextInputChange: (value: string) => void;
   onColorChange: (value: string) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
@@ -27,12 +27,12 @@ function CategoryForm({
           label="카테고리명"
           placeholder="카테고리명을 입력해주세요"
           required={true}
-          value={formData.categoryName}
+          value={formData.name} // 필드 이름 변경
           onChange={onTextInputChange}
         />
         <CircleInput
           onChange={onColorChange}
-          defaultColor={formData.categoryColor}
+          defaultColor={formData.color} // 필드 이름 변경
         />
       </Styled.CategoryListContainer>
       <Styled.ButtonWrapper>

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -3,9 +3,10 @@ import {
   useDeleteCategory,
   useEditCategory,
   useGetCategories,
+  useGetPersonalCategories,
 } from "./useCategories";
 
-import { useGroups } from "./useGroups";
+import { useGetGroups, useGetGroupMembers } from "./useGroups";
 import {
   useCreateGroupSchedule,
   useEditGroupSchedule,
@@ -38,9 +39,11 @@ export {
   useDeleteCategory,
   useEditCategory,
   useGetCategories,
+  useGetPersonalCategories,
 
   // Groups
-  useGroups,
+  useGetGroups,
+  useGetGroupMembers,
   useCreateGroupSchedule,
   useEditGroupSchedule,
   useCreateGroupTodo,

--- a/src/hooks/queries/useCategories.ts
+++ b/src/hooks/queries/useCategories.ts
@@ -10,15 +10,26 @@ import {
   EditCategoryRequest,
 } from "@/types/apiRequest.type";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Category } from "@/types/category.type";
 
 // 카테고리 조회
 export const useGetCategories = () => {
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["categories"], // 키값은 필요하면 바꾸시면 됩니다.
+  return useQuery({
+    queryKey: ["categories"],
     queryFn: () => getCategories(),
   });
+};
 
-  return { data, isLoading, error };
+// 개인 카테고리만 조회
+export const useGetPersonalCategories = () => {
+  return useQuery({
+    queryKey: ["categories"],
+    queryFn: () => getCategories(),
+    select: (response) => ({
+      ...response,
+      data: response.data.filter((category: Category) => !category.groupId),
+    }),
+  });
 };
 
 // 카테고리 생성

--- a/src/hooks/useCategoryForm.ts
+++ b/src/hooks/useCategoryForm.ts
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
 interface FormData {
-  categoryName: string;
-  categoryColor: string;
+  name: string;
+  color: string;
 }
 
 const defaultColor = "var(--color-category1)";
@@ -10,18 +10,18 @@ const defaultColor = "var(--color-category1)";
 function useCategoryForm(defaultData?: FormData) {
   // 초기값 설정 (defaultData 없으면 기본값 사용)
   const [formData, setFormData] = useState<FormData>({
-    categoryName: defaultData?.categoryName || "",
-    categoryColor: defaultData?.categoryColor || defaultColor,
+    name: defaultData?.name || "", // 빈 문자열로 초기화
+    color: defaultData?.color || defaultColor, // 기본 색상 사용
   });
 
   // TextInput 변경 핸들러
   const handleTextInputChange = (value: string) => {
-    setFormData((prev) => ({ ...prev, categoryName: value }));
+    setFormData((prev) => ({ ...prev, name: value }));
   };
 
   // CircleInput 변경 핸들러
   const handleColorChange = (value: string) => {
-    setFormData((prev) => ({ ...prev, categoryColor: value }));
+    setFormData((prev) => ({ ...prev, color: value }));
   };
 
   // 폼 제출 핸들러

--- a/src/pages/categories/CategoriesPage.style.ts
+++ b/src/pages/categories/CategoriesPage.style.ts
@@ -4,7 +4,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100vh;
+  height: 85vh;
   box-sizing: border-box;
 `;
 

--- a/src/pages/categories/CategoriesPage.tsx
+++ b/src/pages/categories/CategoriesPage.tsx
@@ -2,15 +2,13 @@ import Button from "@/components/common/Button/Button";
 import CategoryList from "@/components/feature/CategoryList/CategoryList";
 import * as Styled from "./CategoriesPage.style";
 import { Link } from "react-router-dom";
+import { useGetPersonalCategories } from "@/hooks/queries";
+import { Category } from "@/types/category.type";
 
 function CategoriesPage() {
-  // 예시 데이터 나중에 삭제할 예정
-  const categories = [
-    { categoryId: 1, color: "#ffe3e1", name: "개발" },
-    { categoryId: 2, color: "#fbffe1", name: "영어" },
-    { categoryId: 3, color: "#e1edff", name: "스터디" },
-    { categoryId: 4, color: "#ebffe1", name: "약속" },
-  ];
+  const { data } = useGetPersonalCategories();
+
+  const categories: Category[] = data?.data || [];
 
   return (
     <Styled.Container>

--- a/src/pages/categories/edit/CategoriesEditPage.tsx
+++ b/src/pages/categories/edit/CategoriesEditPage.tsx
@@ -1,24 +1,34 @@
 import useCategoryForm from "@/hooks/useCategoryForm";
 import CategoryForm from "@/components/feature/CatergoryForm/CategoryForm";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useEditCategory } from "@/hooks/queries";
 
 function CategoriesEditPage() {
   const location = useLocation();
+  const navigate = useNavigate();
   const { state } = location as {
-    state: { categoryId: number; color: string; name: string };
+    state: { categoryId: string; color: string; name: string };
   };
+  const { mutate: editCategory } = useEditCategory();
+
   const { formData, handleTextInputChange, handleColorChange, handleSubmit } =
     useCategoryForm({
-      categoryName: state.name,
-      categoryColor: state.color,
+      name: state.name,
+      color: state.color,
     });
 
-  const updateCategory = async (data: {
-    categoryName: string;
-    categoryColor: string;
-  }) => {
-    console.log(data);
-    // PATCH
+  // 카테고리 수정 핸들러
+  const updateCategory = async (data: { name?: string; color?: string }) => {
+    const payload = {
+      categoryId: state.categoryId,
+      ...data,
+    };
+
+    editCategory(payload, {
+      onSuccess: () => {
+        navigate("/categories");
+      },
+    });
   };
 
   return (

--- a/src/pages/categories/new/CategoriesNewPage.tsx
+++ b/src/pages/categories/new/CategoriesNewPage.tsx
@@ -1,16 +1,33 @@
 import useCategoryForm from "@/hooks/useCategoryForm";
 import CategoryForm from "@/components/feature/CatergoryForm/CategoryForm";
+import { useCreateCategory } from "@/hooks/queries/useCategories";
+import { useNavigate } from "react-router-dom";
+import { CreateCategoryRequest } from "@/types/apiRequest.type";
+import { useToast } from "@/hooks/useToast";
 
 function CategoriesNewPage() {
+  const navigate = useNavigate();
+  const { mutate: createCategoryMutation } = useCreateCategory();
+  const { showToast } = useToast();
   const { formData, handleTextInputChange, handleColorChange, handleSubmit } =
     useCategoryForm();
 
-  const createCategory = async (data: {
-    categoryName: string;
-    categoryColor: string;
-  }) => {
-    console.log(data);
-    // POST
+  const createCategory = async (data: { name: string; color: string }) => {
+    const categoryData: CreateCategoryRequest = {
+      name: data.name,
+      color: data.color,
+    };
+
+    createCategoryMutation(categoryData, {
+      onSuccess: () => {
+        showToast("카테고리가 생성되었습니다.", "success");
+        navigate("/categories");
+      },
+      onError: (error) => {
+        console.error("카테고리 생성 에러:", error);
+        showToast("카테고리 생성에 실패했습니다.", "error");
+      },
+    });
   };
 
   return (


### PR DESCRIPTION
## 구현 요약

### 카테고리 조회할 때 개인의 카테고리만 조회할 수 있도록 수정 완료
```typescript
// 개인 카테고리만 조회
export const useGetPersonalCategories = () => {
  return useQuery({
    queryKey: ["categories"],
    queryFn: () => getCategories(),
    select: (response) => ({
      ...response,
      data: response.data.filter((category: Category) => !category.groupId),
    }),
  });
};

``` 
### 카테고리 생성, 삭제, 수정 api 연결해 구현 완료 

### 연관 이슈

- ex) close #135 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
