### PR TITLE
feat: 그룹 투두/일정 생성/수정 페이지 다른 페이지와 연결

### DIFF
--- a/src/components/feature/group/MainList/GroupList.tsx
+++ b/src/components/feature/group/MainList/GroupList.tsx
@@ -51,7 +51,7 @@ function GroupList({
         onClick={() =>
           navigate(`/group/${category.groupId}/schedule/new`, {
             state: {
-              schedules,
+              groupId: category.groupId,
               categoryId: category.categoryId,
               color: category.color,
             },
@@ -84,7 +84,7 @@ function GroupList({
         onClick={() =>
           navigate(`/group/${category.groupId}/todo/new`, {
             state: {
-              todos,
+              groupId: category.groupId,
               categoryId: category.categoryId,
               color: category.color,
             },

--- a/src/pages/group/schedule/new/GroupScheduleNewPage.tsx
+++ b/src/pages/group/schedule/new/GroupScheduleNewPage.tsx
@@ -5,8 +5,13 @@ import { TodoScheduleFormData } from "@/components/form/TodoScheduleForm/utils";
 import { setTodoScheduleForm } from "@/components/form/TodoScheduleForm/utils";
 import { useCreateGroupSchedule } from "@/hooks/queries/useGroupSchedules";
 import { formatDateToYYYYMMDD } from "@/utils/date";
+import { useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 function GroupScheduleNewPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const form = useTodoScheduleForm({
     withEndDate: true,
     withEndTime: true,
@@ -19,9 +24,9 @@ function GroupScheduleNewPage() {
     e.preventDefault();
     if (!form.handleFormValidation()) return;
     // 스케줄 생성 api
-    try {
-      mutate({
-        groupId: "bbbea2e4-3f83-4a63-a69f-309559eb136a",
+    mutate(
+      {
+        groupId: form.groupId,
         scheduleData: {
           title: form.content,
           startDate: formatDateToYYYYMMDD(form.date.start),
@@ -29,20 +34,26 @@ function GroupScheduleNewPage() {
           startTime: form.toggle.isTimeOn ? form.time.start : null,
           endTime: form.toggle.isTimeOn ? form.time.end : null,
           isAlarmed: form.toggle.isAlarmOn,
-          groupId: "bbbea2e4-3f83-4a63-a69f-309559eb136a",
+          groupId: form.groupId,
           assignedMemberList: form.member,
         },
-      });
-      console.log("스케줄 생성 성공");
-    } catch (error) {
-      console.error(error);
-    }
+      },
+      {
+        onSuccess: () => {
+          console.log("일정 생성 성공");
+          navigate(-1);
+        },
+        onError: (error) => {
+          console.error("일정 생성 실패:", error);
+        },
+      }
+    );
   };
 
   useEffect(() => {
-    // 임시 데이터
+    const groupId = location.state?.groupId;
     const data: TodoScheduleFormData = {
-      groupId: "bbbea2e4-3f83-4a63-a69f-309559eb136a",
+      groupId,
     };
     setTodoScheduleForm(form, data);
   }, []);

--- a/src/pages/group/todo/edit/GroupTodoEditPage.tsx
+++ b/src/pages/group/todo/edit/GroupTodoEditPage.tsx
@@ -5,8 +5,13 @@ import { TodoScheduleFormData } from "@/components/form/TodoScheduleForm/utils";
 import { setTodoScheduleForm } from "@/components/form/TodoScheduleForm/utils";
 import { useEditGroupTodo } from "@/hooks/queries/useGroupTodos";
 import { formatDateToYYYYMMDD } from "@/utils/date";
+import { useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 function GroupTodoEditPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const form = useTodoScheduleForm({ withGroup: true });
 
   const { mutate } = useEditGroupTodo();
@@ -15,32 +20,41 @@ function GroupTodoEditPage() {
     e.preventDefault();
     if (!form.handleFormValidation()) return;
     // Todo 수정 api
-    try {
-      mutate({
-        groupId: "bbbea2e4-3f83-4a63-a69f-309559eb136a",
-        todoId: "60277fff-8333-4602-9072-feb2686bb968",
+    mutate(
+      {
+        groupId: form.groupId,
+        todoId: form.todoId || "",
         todoData: {
           title: form.content,
           date: formatDateToYYYYMMDD(form.date.start),
           startTime: form.toggle.isTimeOn ? form.time.start : null,
           userIdList: form.member,
         },
-      });
-      console.log("투두 수정 성공");
-    } catch (error) {
-      console.error(error);
-    }
+      },
+      {
+        onSuccess: () => {
+          console.log("투두 수정 성공");
+          navigate(-1);
+        },
+        onError: (error) => {
+          console.error("투두 수정 실패:", error);
+        },
+      }
+    );
   };
 
   useEffect(() => {
-    // 임시 데이터
+    const state = location.state;
     const data: TodoScheduleFormData = {
-      content: "투두 내용",
-      startDate: new Date(),
-      member: ["64b86382-ac6c-4d0d-9a37-9a11ddc96b79"],
-      startTime: "17:00",
-      isTimeOn: true,
-      groupId: "bbbea2e4-3f83-4a63-a69f-309559eb136a",
+      groupId: state.groupId,
+      todoId: state.groupTodoId,
+      content: state.title,
+      startDate: new Date(state.date),
+      member: state.userIdList.map(
+        (item: { done: boolean; userId: string }) => item.userId
+      ),
+      startTime: state.startTime,
+      isTimeOn: !!state.startTime,
     };
     setTodoScheduleForm(form, data);
   }, []);

--- a/src/pages/group/todo/new/GroupTodoNewPage.tsx
+++ b/src/pages/group/todo/new/GroupTodoNewPage.tsx
@@ -5,8 +5,13 @@ import { useEffect } from "react";
 import { TodoScheduleFormData } from "@/components/form/TodoScheduleForm/utils";
 import { useCreateGroupTodo } from "@/hooks/queries/useGroupTodos";
 import { formatDateToYYYYMMDD } from "@/utils/date";
+import { useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 function GroupTodoNewPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const form = useTodoScheduleForm({ withGroup: true });
 
   const { mutate } = useCreateGroupTodo();
@@ -15,26 +20,32 @@ function GroupTodoNewPage() {
     e.preventDefault();
     if (!form.handleFormValidation()) return;
     // Todo 생성 api
-    try {
-      mutate({
-        groupId: "bbbea2e4-3f83-4a63-a69f-309559eb136a",
+    mutate(
+      {
+        groupId: form.groupId,
         todoData: {
           title: form.content,
           date: formatDateToYYYYMMDD(form.date.start),
           startTime: form.toggle.isTimeOn ? form.time.start : null,
           userIdList: form.member,
         },
-      });
-      console.log("투두 생성 성공");
-    } catch (error) {
-      console.error(error);
-    }
+      },
+      {
+        onSuccess: () => {
+          console.log("투두 생성 성공");
+          navigate(-1);
+        },
+        onError: (error) => {
+          console.error("투두 생성 실패:", error);
+        },
+      }
+    );
   };
 
   useEffect(() => {
-    // 임시 데이터
+    const groupId = location.state?.groupId;
     const data: TodoScheduleFormData = {
-      groupId: "bbbea2e4-3f83-4a63-a69f-309559eb136a",
+      groupId,
     };
     setTodoScheduleForm(form, data);
   }, []);


### PR DESCRIPTION
## 구현 요약

- 이전 페이지에서 넘겨주는 props값 변경
- 그룹 투두 생성 페이지 다른 페이지와 연결
- 그룹 투두 수정 페이지 다른 페이지와 연결
- 그룹 투두 생성 페이지 다른 페이지와 연결
- 그룹 일정 수정 페이지 다른 페이지와 연결

### 연관 이슈

- close #149 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
