### PR TITLE
feat: 그룹 데이터 없을 경우 및 수정 페이지 로직 수정

### DIFF
--- a/src/components/feature/GroupNewPage/MemberList.tsx
+++ b/src/components/feature/GroupNewPage/MemberList.tsx
@@ -10,6 +10,10 @@ import { postInvitation } from "@/apis/group/postInvitation";
 import { getMember } from "@/apis/group/getMember";
 import { deleteMember } from "@/apis/group/deleteMember";
 
+interface MemberListProps {
+  groupId: string;
+}
+
 interface UserData {
   groupSettingId: string;
   userId: string;
@@ -17,9 +21,9 @@ interface UserData {
   role: string;
 }
 
-function MemberList() {
+function MemberList({ groupId }: MemberListProps) {
   // 테스트용 group_id, 나중엔 props 또는 useLocation을 사용하지 않을까 싶습니다.
-  const groupId = "a85e5db7-593f-429a-bc80-385408f0b934";
+  // const group_id = "a85e5db7-593f-429a-bc80-385408f0b934";
   const [nickname, setNickname] = useState("");
   const [memberList, setMemberList] = useState<UserData[]>([]);
 
@@ -51,8 +55,8 @@ function MemberList() {
       setMemberList((prevList) =>
         prevList.filter((user) => user.groupSettingId !== groupSettingId)
       );
-    } else if (res.code === 404 || res.code === 401) {
-      toast.error(res.message);
+    } else if (res.status === 404 || res.status === 401) {
+      toast.error(res.response.data.message);
     }
   };
 

--- a/src/hooks/useGroupEditForm.ts
+++ b/src/hooks/useGroupEditForm.ts
@@ -23,13 +23,27 @@ function useGroupEditForm(initialState: UseGroupEditProps) {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const res = await putGroup({ formData });
-    if (res.code == 200) {
-      // 토스트 메세지를 띄우지 않는 이유는 navigate시 변경되어 있기 때문
-      navigate("/group/1");
-    } else {
-      toast.error("잠시후 다시 시도해주세요.");
-    }
+    putGroup({ formData })
+      .then((res) => {
+        console.log(res);
+        if (res.code == 200) {
+          navigate("/group/1");
+        } else if (res.status == 403) {
+          toast.error(res.response.data.message);
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+        // toast.error(err.response.data.message);
+      });
+
+    // if (res.status == 200) {
+    //   // 토스트 메세지를 띄우지 않는 이유는 navigate시 변경되어 있기 때문
+    //   navigate("/group/1");
+    // } else {
+    //   console.log(res);
+    //   toast.error(res.response.data.message);
+    // }
   };
 
   return {

--- a/src/pages/group/edit/GroupEditPage.tsx
+++ b/src/pages/group/edit/GroupEditPage.tsx
@@ -1,30 +1,23 @@
 import * as Styled from "./GroupEditPage.style";
+import { useLocation } from "react-router-dom";
 import Button from "@/components/common/Button/Button";
 import CircleInput from "@/components/common/Circle/CircleInput";
 import MemberList from "@/components/feature/GroupNewPage/MemberList";
 import TextInput from "@/components/common/TextInput/TextInput";
 import useGroupEditForm from "@/hooks/useGroupEditForm";
 
-interface GroupEditPageProps {
-  groupName?: string;
-  color?: string;
-  description?: string;
-}
-
 // 수정 페이지에서는 color랑 description 만 변경됨.
 // 데이터를 props를 통해 받게 되어있는데, useParam or useLocation에 맞춰 추후 수정 필요
 
 // **가장 중요** -> 그룹 수정 api 연동해야 함
-function GroupEditPage({
-  groupName = "DBDB DEEP",
-  color = "#c9c9c9",
-  description = "설명설명~",
-}: GroupEditPageProps) {
+function GroupEditPage() {
+  const location = useLocation();
+  console.log(location.state); //
   const { formData, handleChange, handleSubmit } = useGroupEditForm({
-    groupName,
-    initialColor: color,
-    description,
-    groupId: "a85e5db7-593f-429a-bc80-385408f0b934",
+    groupName: location.state.groupName || "",
+    initialColor: location.state.color || "#FFFFFF",
+    description: location.state.description || "",
+    groupId: location.state.groupId,
   });
 
   return (
@@ -48,7 +41,7 @@ function GroupEditPage({
         value={formData.description}
         onChange={handleChange("description")}
       />
-      <MemberList />
+      <MemberList groupId={location.state.groupId} />
       <CircleInput
         defaultColor={formData.initialColor}
         onChange={(value) => handleChange("initialColor")(value)}

--- a/src/pages/group/noData/GroupNoData.tsx
+++ b/src/pages/group/noData/GroupNoData.tsx
@@ -13,8 +13,11 @@ function GroupNoData() {
     getGroup()
       .then((res) => {
         console.log(res);
+        if (res.data.length > 0) {
+          // navigate(`/group/${res.data[0].groupId}`);
+          navigate(`/group/1`);
+        }
         // /group/1 이 경로로 그룹 캘린더가 생길지도 모르겠음
-        navigate("/group/1");
       })
       .catch((err) => console.log(err));
   }, []);


### PR DESCRIPTION
## 구현 요약

- 그룹 여부에 따라 페이지 이동이 적용되지 않았던 부분을 수정 했습니다.
- 그룹 수정페이지에 데이터들을 `location state`로 연결했습니다.
  - 수정 api가 동작하는 것을 확인 했습니다.
  - 그룹원 삭제 api는 그룹원이어서 확인을 못했지만 에러 메시지(접근 권한이 없습니다)를 toast 메세지로 띄웠습니다.

### 연관 이슈

- close #151 

## 체크 리스트

- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
